### PR TITLE
Feature auth integration

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -20,6 +20,7 @@
   "eslintConfig": {
     "extends": "react-app"
   },
+  "proxy": "http://localhost:5000",
   "browserslist": {
     "production": [
       ">0.2%",

--- a/client/src/components/Login.js
+++ b/client/src/components/Login.js
@@ -59,15 +59,15 @@ function Login (){
     const classes = useStyles();
     const [email,setEmail]=useState('');
     const [password, setPassword]=useState('');
-    const [errors, setErrors]=useState('');
+    const [errors, setErrors]=useState({});
 
     const validations = () => {
-        let temp = {};
-        temp.email = email ? "" : "Please enter an email.";
-        temp.password = password ? "" : "Please enter a password.";
-        setErrors({ ...temp });
+        const errorsCopy = {...errors};
+        errorsCopy.email = email ? "" : "Please enter an email.";
+        errorsCopy.password = password ? "" : "Please enter a password.";
+        setErrors({ ...errorsCopy });
 
-        return Object.values(temp).every(x => x == "");
+        return Object.values(errorsCopy).every(field => field === "");
     }
 
     const handleClick = (e) => {
@@ -83,7 +83,7 @@ function Login (){
                     'password': password,
                 })})
                 .then(response => response.json())
-                .then(function(response) {
+                .then((response) => {
                     if (response.status === 'success') {
                         console.log('Success:', email);
                     }
@@ -97,16 +97,16 @@ function Login (){
                 })
             }
     }
-    // The console throws a warning because the 'error' field in each TextField is given a string, not a boolean. However, the code appears to work as intended, and it does not appear to be a problem.
+
     return(
             <section className={classes.login}>
                 <Box className={classes.formContainer}>
                     <form>
                         <h2 className={classes.h2}>Sign in</h2>
                         <label>Your email address:</label>
-                        <TextField className={classes.textField} variant="outlined" label="email"  fullWidth required type="email" error={errors.email} helperText={errors.email} onChange={(e)=>setEmail(e.target.value)}/>
+                        <TextField className={classes.textField} variant="outlined" label="email"  fullWidth required type="email" error={!!errors.email} helperText={errors.email} onChange={(e)=>setEmail(e.target.value)}/>
                         <label>Password:</label>
-                        <TextField className={classes.textField} variant="outlined" label="password" fullWidth required type="password" error={errors.password} helperText={errors.password} onChange={(e)=>setPassword(e.target.value)}/>
+                        <TextField className={classes.textField} variant="outlined" label="password" fullWidth required type="password" error={!!errors.password} helperText={errors.password} onChange={(e)=>setPassword(e.target.value)}/>
                         <Button className={classes.button} variant="contained" color="secondary" onClick={handleClick}>Login</Button>
                     </form>
                     <Box className={classes.signup}>

--- a/client/src/components/Login.js
+++ b/client/src/components/Login.js
@@ -57,8 +57,8 @@ signupLink:{
 }));
 function Login (){
     const classes = useStyles();
-    const [userEmail,setEmail]=useState('')
-    const [userPass, setPass]=useState('')
+    const [email,setEmail]=useState('')
+    const [password, setPass]=useState('')
     return(
             <section className={classes.login}>
                 <Box className={classes.formContainer}>

--- a/client/src/components/Login.js
+++ b/client/src/components/Login.js
@@ -59,6 +59,22 @@ function Login (){
     const classes = useStyles();
     const [email,setEmail]=useState('')
     const [password, setPass]=useState('')
+    const handleClick = () => {
+        fetch("/auth/login", {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({
+                'email': email,
+                'password': password,
+            })})
+            .then(response => response.json())
+            .then(console.log('Success')) // Logs success even when unsuccessful, not certain how to fix it.
+            .catch((error) => {
+                console.error('Error:', error)
+            })
+    }
     return(
             <section className={classes.login}>
                 <Box className={classes.formContainer}>
@@ -68,7 +84,7 @@ function Login (){
                         <TextField className={classes.textField} variant="outlined" label="email"  fullWidth required type="email"  onChange={(e)=>setEmail(e.target.value)}/>
                         <label>Password:</label>
                         <TextField className={classes.textField} variant="outlined" label="password" fullWidth required type="password" onChange={(e)=>setPass(e.target.value)}/>
-                        <Button className={classes.button} variant="contained" color="secondary" >Login</Button>
+                        <Button className={classes.button} variant="contained" color="secondary" onClick={handleClick}>Login</Button>
                     </form>
                     <Box className={classes.signup}>
                         <p className={classes.p}>Don't have an account?</p>

--- a/client/src/components/Login.js
+++ b/client/src/components/Login.js
@@ -57,33 +57,56 @@ signupLink:{
 }));
 function Login (){
     const classes = useStyles();
-    const [email,setEmail]=useState('')
-    const [password, setPass]=useState('')
-    const handleClick = () => {
-        fetch("/auth/login", {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json'
-            },
-            body: JSON.stringify({
-                'email': email,
-                'password': password,
-            })})
-            .then(response => response.json())
-            .then(console.log('Success')) // Logs success even when unsuccessful, not certain how to fix it.
-            .catch((error) => {
-                console.error('Error:', error)
-            })
+    const [email,setEmail]=useState('');
+    const [password, setPassword]=useState('');
+    const [errors, setErrors]=useState('');
+
+    const validations = () => {
+        let temp = {};
+        temp.email = email ? "" : "Please enter an email.";
+        temp.password = password ? "" : "Please enter a password.";
+        setErrors({ ...temp });
+
+        return Object.values(temp).every(x => x == "");
     }
+
+    const handleClick = (e) => {
+        e.preventDefault();
+        if (validations()) {
+            fetch("/auth/login", {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify({
+                    'email': email,
+                    'password': password,
+                })})
+                .then(response => response.json())
+                .then(function(response) {
+                    if (response.status === 'success') {
+                        console.log('Success:', email);
+                    }
+                    else {
+                        window.alert(response.message);
+                        console.log(response.message);
+                    }
+                })
+                .catch((error) => {
+                    console.error('Error:', error)
+                })
+            }
+    }
+    // The console throws a warning because the 'error' field in each TextField is given a string, not a boolean. However, the code appears to work as intended, and it does not appear to be a problem.
     return(
             <section className={classes.login}>
                 <Box className={classes.formContainer}>
                     <form>
                         <h2 className={classes.h2}>Sign in</h2>
                         <label>Your email address:</label>
-                        <TextField className={classes.textField} variant="outlined" label="email"  fullWidth required type="email"  onChange={(e)=>setEmail(e.target.value)}/>
+                        <TextField className={classes.textField} variant="outlined" label="email"  fullWidth required type="email" error={errors.email} helperText={errors.email} onChange={(e)=>setEmail(e.target.value)}/>
                         <label>Password:</label>
-                        <TextField className={classes.textField} variant="outlined" label="password" fullWidth required type="password" onChange={(e)=>setPass(e.target.value)}/>
+                        <TextField className={classes.textField} variant="outlined" label="password" fullWidth required type="password" error={errors.password} helperText={errors.password} onChange={(e)=>setPassword(e.target.value)}/>
                         <Button className={classes.button} variant="contained" color="secondary" onClick={handleClick}>Login</Button>
                     </form>
                     <Box className={classes.signup}>

--- a/client/src/components/SignUp.js
+++ b/client/src/components/SignUp.js
@@ -7,7 +7,7 @@ const useStyles = makeStyles((theme)=>({
 login:{
     maxWidth:'1200px',
     margin:'0 auto',
-    height:'100vh',
+    height:'123vh', // Eyeballed to make the form centered in the background. May be a better way to do this.
     padding:'50px',
     backgroundColor:'#44475ab9',
 },
@@ -54,9 +54,29 @@ signupLink:{
 }));
 function SignUp (){
     const classes = useStyles();
-    const [userName, setName]=useState('')
-    const [userEmail,setEmail]=useState('')
-    const [userPass, setPass]=useState('')
+    const [name, setName]=useState('')  // Changed names to correspond with backend.
+    const [email,setEmail]=useState('')
+    const [password, setPass]=useState('')
+    const [confirm, setConfirm]=useState('')
+    const handleClick = () => {
+        fetch("/auth/register", {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({
+                'name': name,
+                'email': email,
+                'password': password,
+                'confirm': confirm
+            })})
+            .then(response => response.json())
+            .then(console.log('Success:', name))
+            .catch((error) => {
+                console.error('Error:', error)
+            })
+    }
+    // Added confirm password field. Still needs to check for password being at least six characters
     return(
             <section className={classes.login}>
                 <Box className={classes.formContainer}>
@@ -68,11 +88,13 @@ function SignUp (){
                         <TextField className={classes.textField} variant="outlined" label="email"  fullWidth required type="email"  onChange={(e)=>setEmail(e.target.value)}/>
                         <label>Password:</label>
                         <TextField className={classes.textField} variant="outlined" label="password" fullWidth required type="password" onChange={(e)=>setPass(e.target.value)}/>
-                        <Button className={classes.button} variant="contained" color="secondary" >Login</Button>
+                        <label>Confirm Password:</label>
+                        <TextField className={classes.textField} variant="outlined" label="confirm password" fullWidth required type="password" onChange={(e)=>setConfirm(e.target.value)}/>
+                        <Button className={classes.button} variant="contained" color="secondary" onClick={handleClick}>Register</Button>
                     </form>
                     <Box className={classes.signup}>
-                        <p className={classes.p}>Don't have an account?</p>
-                        <Link className={classes.signupLink} to="/login">Create an account</Link>
+                        <p className={classes.p}>Already have an account?</p>
+                        <Link className={classes.signupLink} to="/login">Login</Link>
                     </Box>
                 </Box>
             </section>

--- a/client/src/components/SignUp.js
+++ b/client/src/components/SignUp.js
@@ -54,42 +54,66 @@ signupLink:{
 }));
 function SignUp (){
     const classes = useStyles();
-    const [name, setName]=useState('')  // Changed names to correspond with backend.
-    const [email,setEmail]=useState('')
-    const [password, setPass]=useState('')
-    const [confirm, setConfirm]=useState('')
-    const handleClick = () => {
-        fetch("/auth/register", {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json'
-            },
-            body: JSON.stringify({
-                'name': name,
-                'email': email,
-                'password': password,
-                'confirm': confirm
-            })})
-            .then(response => response.json())
-            .then(console.log('Success:', name)) // Logs success even when unsuccessful, not certain how to fix it.
-            .catch((error) => {
-                console.error('Error:', error)
-            })
+    const [name, setName]=useState('');
+    const [email,setEmail]=useState('');
+    const [password, setPass]=useState('');
+    const [confirm, setConfirm]=useState('');
+    const [errors, setErrors]=useState('');
+
+    const validations = () => {
+        let temp = {};
+        temp.name = name ? "" : "This field is required.";
+        temp.email = (/.+@.+..+/).test(email) ? "" : "Email is not valid.";
+        temp.password = password.length > 5 ? "" : "Password must be at least six characters.";
+        temp.confirm = password === confirm ? "" : "Passwords must match.";
+        setErrors({ ...temp });
+
+        return Object.values(temp).every(x => x == "");
     }
-    // Added confirm password field. Still needs to check for password being at least six characters
+
+    const handleClick = (e) => {
+        e.preventDefault();
+        if (validations()) {
+            fetch("/auth/register", {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify({
+                    'name': name,
+                    'email': email,
+                    'password': password,
+                    'confirm': confirm
+                })})
+                .then(response => response.json())
+                .then(function(response) {
+                    if (response.status === 'success') {
+                        console.log('Success:', email);
+                    }
+                    else {
+                        window.alert(response.message);
+                        console.log(response.message);
+                    }
+                })
+                .catch((error) => {
+                    console.error('Error:', error);
+                })
+            }
+    }
+    // The console throws a warning because the 'error' field in each TextField is given a string, not a boolean. However, the code appears to work as intended, and it does not appear to be a problem.
     return(
             <section className={classes.login}>
                 <Box className={classes.formContainer}>
                     <form>
                         <h2 className={classes.h2}>Sign up</h2>
                         <label>Your Name</label>
-                        <TextField className={classes.textField} variant="outlined" label="name"  fullWidth required type="text"  onChange={(e)=>setName(e.target.value)}/>
+                        <TextField className={classes.textField} variant="outlined" label="name"  fullWidth required type="text" error={errors.name} helperText={errors.name} onChange={(e)=>setName(e.target.value)}/>
                         <label>Your email address:</label>
-                        <TextField className={classes.textField} variant="outlined" label="email"  fullWidth required type="email"  onChange={(e)=>setEmail(e.target.value)}/>
+                        <TextField className={classes.textField} variant="outlined" label="email"  fullWidth required type="email" error={errors.email} helperText={errors.email} onChange={(e)=>setEmail(e.target.value)}/>
                         <label>Password:</label>
-                        <TextField className={classes.textField} variant="outlined" label="password" fullWidth required type="password" onChange={(e)=>setPass(e.target.value)}/>
+                        <TextField className={classes.textField} variant="outlined" label="password" fullWidth required type="password" error={errors.password} helperText={errors.password} onChange={(e)=>setPass(e.target.value)}/>
                         <label>Confirm Password:</label>
-                        <TextField className={classes.textField} variant="outlined" label="confirm password" fullWidth required type="password" onChange={(e)=>setConfirm(e.target.value)}/>
+                        <TextField className={classes.textField} variant="outlined" label="confirm password" fullWidth required type="password" error={errors.confirm} helperText={errors.confirm} onChange={(e)=>setConfirm(e.target.value)}/>
                         <Button className={classes.button} variant="contained" color="secondary" onClick={handleClick}>Register</Button>
                     </form>
                     <Box className={classes.signup}>

--- a/client/src/components/SignUp.js
+++ b/client/src/components/SignUp.js
@@ -7,7 +7,7 @@ const useStyles = makeStyles((theme)=>({
 login:{
     maxWidth:'1200px',
     margin:'0 auto',
-    height:'123vh', // Eyeballed to make the form centered in the background. May be a better way to do this.
+    height:'123vh',
     padding:'50px',
     backgroundColor:'#44475ab9',
 },
@@ -56,19 +56,19 @@ function SignUp (){
     const classes = useStyles();
     const [name, setName]=useState('');
     const [email,setEmail]=useState('');
-    const [password, setPass]=useState('');
+    const [password, setPassword]=useState('');
     const [confirm, setConfirm]=useState('');
-    const [errors, setErrors]=useState('');
+    const [errors, setErrors]=useState({});
 
     const validations = () => {
-        let temp = {};
-        temp.name = name ? "" : "This field is required.";
-        temp.email = (/.+@.+..+/).test(email) ? "" : "Email is not valid.";
-        temp.password = password.length > 5 ? "" : "Password must be at least six characters.";
-        temp.confirm = password === confirm ? "" : "Passwords must match.";
-        setErrors({ ...temp });
+        const errorsCopy = {...errors};
+        errorsCopy.name = name ? "" : "This field is required.";
+        errorsCopy.email = (/.+@.+..+/).test(email) ? "" : "Email is not valid.";
+        errorsCopy.password = password.length > 5 ? "" : "Password must be at least six characters.";
+        errorsCopy.confirm = password === confirm ? "" : "Passwords must match.";
+        setErrors({ ...errorsCopy });
 
-        return Object.values(temp).every(x => x == "");
+        return Object.values(errorsCopy).every(field => field === "");
     }
 
     const handleClick = (e) => {
@@ -91,7 +91,7 @@ function SignUp (){
                         console.log('Success:', email);
                     }
                     else {
-                        window.alert(response.message);
+                        window.alert(response.message); // Replace with snackbar.
                         console.log(response.message);
                     }
                 })
@@ -100,20 +100,20 @@ function SignUp (){
                 })
             }
     }
-    // The console throws a warning because the 'error' field in each TextField is given a string, not a boolean. However, the code appears to work as intended, and it does not appear to be a problem.
+
     return(
             <section className={classes.login}>
                 <Box className={classes.formContainer}>
                     <form>
                         <h2 className={classes.h2}>Sign up</h2>
                         <label>Your Name</label>
-                        <TextField className={classes.textField} variant="outlined" label="name"  fullWidth required type="text" error={errors.name} helperText={errors.name} onChange={(e)=>setName(e.target.value)}/>
+                        <TextField className={classes.textField} variant="outlined" label="name"  fullWidth required type="text" error={!!errors.name} helperText={errors.name} onChange={(e)=>setName(e.target.value)}/>
                         <label>Your email address:</label>
-                        <TextField className={classes.textField} variant="outlined" label="email"  fullWidth required type="email" error={errors.email} helperText={errors.email} onChange={(e)=>setEmail(e.target.value)}/>
+                        <TextField className={classes.textField} variant="outlined" label="email"  fullWidth required type="email" error={!!errors.email} helperText={errors.email} onChange={(e)=>setEmail(e.target.value)}/>
                         <label>Password:</label>
-                        <TextField className={classes.textField} variant="outlined" label="password" fullWidth required type="password" error={errors.password} helperText={errors.password} onChange={(e)=>setPass(e.target.value)}/>
+                        <TextField className={classes.textField} variant="outlined" label="password" fullWidth required type="password" error={!!errors.password} helperText={errors.password} onChange={(e)=>setPassword(e.target.value)}/>
                         <label>Confirm Password:</label>
-                        <TextField className={classes.textField} variant="outlined" label="confirm password" fullWidth required type="password" error={errors.confirm} helperText={errors.confirm} onChange={(e)=>setConfirm(e.target.value)}/>
+                        <TextField className={classes.textField} variant="outlined" label="confirm password" fullWidth required type="password" error={!!errors.confirm} helperText={errors.confirm} onChange={(e)=>setConfirm(e.target.value)}/>
                         <Button className={classes.button} variant="contained" color="secondary" onClick={handleClick}>Register</Button>
                     </form>
                     <Box className={classes.signup}>

--- a/client/src/components/SignUp.js
+++ b/client/src/components/SignUp.js
@@ -71,7 +71,7 @@ function SignUp (){
                 'confirm': confirm
             })})
             .then(response => response.json())
-            .then(console.log('Success:', name))
+            .then(console.log('Success:', name)) // Logs success even when unsuccessful, not certain how to fix it.
             .catch((error) => {
                 console.error('Error:', error)
             })

--- a/server/api/auth_handler.py
+++ b/server/api/auth_handler.py
@@ -55,6 +55,7 @@ class RegisterAPI(MethodView):
                     return make_response(jsonify(responseObject)), 401
                 user = User(
                     email=post_data.get("email"),
+                    name=post_data.get("name"),
                     password=post_data.get("password")
                 )
                 db.session.add(user)

--- a/server/models/user.py
+++ b/server/models/user.py
@@ -8,9 +8,7 @@ class User(db.Model):
 
     id = db.Column(db.Integer, primary_key=True, autoincrement=True)
     email = db.Column(db.String(255), unique=True, nullable=False)
-    name = db.Column(db.String(255), nullable=False)  # Right now this is a very simple full name column. Could be
-    # possibly better to include first and last name fields in the front-end form and make this two columns, one for
-    # first names and one for last names.
+    name = db.Column(db.String(255), nullable=False)
     password = db.Column(db.String(255), nullable=False)
     registered_time = db.Column(db.DateTime, nullable=False)
 

--- a/server/models/user.py
+++ b/server/models/user.py
@@ -8,11 +8,15 @@ class User(db.Model):
 
     id = db.Column(db.Integer, primary_key=True, autoincrement=True)
     email = db.Column(db.String(255), unique=True, nullable=False)
+    name = db.Column(db.String(255), nullable=False)  # Right now this is a very simple full name column. Could be
+    # possibly better to include first and last name fields in the front-end form and make this two columns, one for
+    # first names and one for last names.
     password = db.Column(db.String(255), nullable=False)
     registered_time = db.Column(db.DateTime, nullable=False)
 
-    def __init__(self, email, password):
+    def __init__(self, email, name, password):
         self.email = email
+        self.name = name
         self.password = flask_bcrypt.generate_password_hash(password, app.config.get("BCRYPT_LOG_ROUNDS")).decode()
         self.registered_time = datetime.datetime.now(tz=datetime.timezone.utc)
 


### PR DESCRIPTION
--What it does--
-Integrates the front-end login and sign-up pages with the back-end APIs
-A touch of redesign to make the front-end work better with the added field of confirm password.
-Also adds support on the backend for the name variable in the form.

--What it avoids--
-I did not redirect users after registering or logging in. I think that would be better addressed once protected routes are finished.
-I did not notify the user what went wrong if the registration or login fails. I've largely kept this pull request to providing the basic functionality needed to make the front-end auth pages connect to the back-end auth APIs, but I want to acknowledge that there is more to do to make it operate the way we want it to.
-I did not store the name as individual first and last names in the database. That can be added if needed, but as is I think it may make more sense to avoiding adding a line to the form by asking for first name and last name.

--What to look for--
-There are a couple problems noted in the comments that I am unsure how to fix. It still works, but it could work better in some contexts.
-If there is an issue which I did not address that should be addressed in this pull request.