### PR TITLE
Bugfix auth integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ instance/
 
 #TODO add .env to your gitignore
 
+server/api/celery_api/celerybeat-schedule.bak
+server/api/celery_api/celerybeat-schedule.dat
+server/api/celery_api/celerybeat-schedule.dir

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1155,9 +1155,9 @@
       "integrity": "sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg=="
     },
     "@emotion/hash": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.7.2.tgz",
-      "integrity": "sha512-RMtr1i6E8MXaBWwhXL3yeOU8JXRnz8GNxHvaUfVvwxokvayUY0zoBeWbKw1S9XkufmGEEdQd228pSZXFkAln8Q=="
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
+      "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
     },
     "@hapi/address": {
       "version": "2.1.4",
@@ -1385,42 +1385,31 @@
       }
     },
     "@material-ui/core": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-4.1.3.tgz",
-      "integrity": "sha512-cSrI3yZ2L1XVi5IyO0/dPGUq1FaDBKTL9ygDOlvojD6bGuD/Qu17dCFAD8/mHV4CPNQMJYUKLYyOmqtDYdEB9g==",
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-4.11.0.tgz",
+      "integrity": "sha512-bYo9uIub8wGhZySHqLQ833zi4ZML+XCBE1XwJ8EuUVSpTWWG57Pm+YugQToJNFsEyiKFhPh8DPD0bgupz8n01g==",
       "requires": {
-        "@babel/runtime": "^7.2.0",
-        "@material-ui/styles": "^4.1.2",
-        "@material-ui/system": "^4.3.0",
-        "@material-ui/types": "^4.1.1",
-        "@material-ui/utils": "^4.1.0",
-        "@types/react-transition-group": "^2.0.16",
-        "clsx": "^1.0.2",
-        "convert-css-length": "^2.0.0",
-        "debounce": "^1.1.0",
-        "deepmerge": "^3.0.0",
-        "hoist-non-react-statics": "^3.2.1",
-        "is-plain-object": "^3.0.0",
-        "normalize-scroll-left": "^0.2.0",
-        "popper.js": "^1.14.1",
+        "@babel/runtime": "^7.4.4",
+        "@material-ui/styles": "^4.10.0",
+        "@material-ui/system": "^4.9.14",
+        "@material-ui/types": "^5.1.0",
+        "@material-ui/utils": "^4.10.2",
+        "@types/react-transition-group": "^4.2.0",
+        "clsx": "^1.0.4",
+        "hoist-non-react-statics": "^3.3.2",
+        "popper.js": "1.16.1-lts",
         "prop-types": "^15.7.2",
-        "react-event-listener": "^0.6.6",
-        "react-transition-group": "^4.0.0",
-        "warning": "^4.0.1"
+        "react-is": "^16.8.0",
+        "react-transition-group": "^4.4.0"
       },
       "dependencies": {
-        "is-plain-object": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.0.tgz",
-          "integrity": "sha512-tZIpofR+P05k8Aocp7UI/2UTa9lTJSebCXpFFoR9aibpokDj/uXBsJ8luUu0tTVYKkMU6URDUuOfJZ7koewXvg==",
+        "hoist-non-react-statics": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+          "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
           "requires": {
-            "isobject": "^4.0.0"
+            "react-is": "^16.7.0"
           }
-        },
-        "isobject": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
-          "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA=="
         }
       }
     },
@@ -1432,56 +1421,85 @@
         "@babel/runtime": "^7.4.4"
       }
     },
-    "@material-ui/styles": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@material-ui/styles/-/styles-4.1.2.tgz",
-      "integrity": "sha512-IRwhGI3OzxMKIDXnYl/vi9FD/i5ZktVP2m/5PIf/HVdvhqUZGIzqR2OB/9f3W1hc+kKKExdOPlpZpVihIsJWkA==",
+    "@material-ui/lab": {
+      "version": "4.0.0-alpha.56",
+      "resolved": "https://registry.npmjs.org/@material-ui/lab/-/lab-4.0.0-alpha.56.tgz",
+      "integrity": "sha512-xPlkK+z/6y/24ka4gVJgwPfoCF4RCh8dXb1BNE7MtF9bXEBLN/lBxNTK8VAa0qm3V2oinA6xtUIdcRh0aeRtVw==",
       "requires": {
-        "@babel/runtime": "^7.2.0",
-        "@emotion/hash": "^0.7.1",
-        "@material-ui/types": "^4.1.1",
-        "@material-ui/utils": "^4.1.0",
-        "clsx": "^1.0.2",
-        "csstype": "^2.5.2",
-        "deepmerge": "^3.0.0",
-        "hoist-non-react-statics": "^3.2.1",
-        "jss": "10.0.0-alpha.17",
-        "jss-plugin-camel-case": "10.0.0-alpha.17",
-        "jss-plugin-default-unit": "10.0.0-alpha.17",
-        "jss-plugin-global": "10.0.0-alpha.17",
-        "jss-plugin-nested": "10.0.0-alpha.17",
-        "jss-plugin-props-sort": "10.0.0-alpha.17",
-        "jss-plugin-rule-value-function": "10.0.0-alpha.17",
-        "jss-plugin-vendor-prefixer": "10.0.0-alpha.17",
+        "@babel/runtime": "^7.4.4",
+        "@material-ui/utils": "^4.10.2",
+        "clsx": "^1.0.4",
         "prop-types": "^15.7.2",
-        "warning": "^4.0.1"
+        "react-is": "^16.8.0"
+      },
+      "dependencies": {
+        "@material-ui/utils": {
+          "version": "4.10.2",
+          "resolved": "https://registry.npmjs.org/@material-ui/utils/-/utils-4.10.2.tgz",
+          "integrity": "sha512-eg29v74P7W5r6a4tWWDAAfZldXIzfyO1am2fIsC39hdUUHm/33k6pGOKPbgDjg/U/4ifmgAePy/1OjkKN6rFRw==",
+          "requires": {
+            "@babel/runtime": "^7.4.4",
+            "prop-types": "^15.7.2",
+            "react-is": "^16.8.0"
+          }
+        }
+      }
+    },
+    "@material-ui/styles": {
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/@material-ui/styles/-/styles-4.10.0.tgz",
+      "integrity": "sha512-XPwiVTpd3rlnbfrgtEJ1eJJdFCXZkHxy8TrdieaTvwxNYj42VnnCyFzxYeNW9Lhj4V1oD8YtQ6S5Gie7bZDf7Q==",
+      "requires": {
+        "@babel/runtime": "^7.4.4",
+        "@emotion/hash": "^0.8.0",
+        "@material-ui/types": "^5.1.0",
+        "@material-ui/utils": "^4.9.6",
+        "clsx": "^1.0.4",
+        "csstype": "^2.5.2",
+        "hoist-non-react-statics": "^3.3.2",
+        "jss": "^10.0.3",
+        "jss-plugin-camel-case": "^10.0.3",
+        "jss-plugin-default-unit": "^10.0.3",
+        "jss-plugin-global": "^10.0.3",
+        "jss-plugin-nested": "^10.0.3",
+        "jss-plugin-props-sort": "^10.0.3",
+        "jss-plugin-rule-value-function": "^10.0.3",
+        "jss-plugin-vendor-prefixer": "^10.0.3",
+        "prop-types": "^15.7.2"
+      },
+      "dependencies": {
+        "hoist-non-react-statics": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+          "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+          "requires": {
+            "react-is": "^16.7.0"
+          }
+        }
       }
     },
     "@material-ui/system": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@material-ui/system/-/system-4.3.0.tgz",
-      "integrity": "sha512-VQh3mWZSmzm1JR7Ci35AHKwOhhxHHMrBWCdP4mh7UAwSdjWBE6s2Y9Y0iJiqMoEsHP64vU3W1JpsW2AgkUeHsQ==",
+      "version": "4.9.14",
+      "resolved": "https://registry.npmjs.org/@material-ui/system/-/system-4.9.14.tgz",
+      "integrity": "sha512-oQbaqfSnNlEkXEziDcJDDIy8pbvwUmZXWNqlmIwDqr/ZdCK8FuV3f4nxikUh7hvClKV2gnQ9djh5CZFTHkZj3w==",
       "requires": {
-        "@babel/runtime": "^7.2.0",
-        "deepmerge": "^3.0.0",
-        "prop-types": "^15.7.2",
-        "warning": "^4.0.1"
+        "@babel/runtime": "^7.4.4",
+        "@material-ui/utils": "^4.9.6",
+        "csstype": "^2.5.2",
+        "prop-types": "^15.7.2"
       }
     },
     "@material-ui/types": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@material-ui/types/-/types-4.1.1.tgz",
-      "integrity": "sha512-AN+GZNXytX9yxGi0JOfxHrRTbhFybjUJ05rnsBVjcB+16e466Z0Xe5IxawuOayVZgTBNDxmPKo5j4V6OnMtaSQ==",
-      "requires": {
-        "@types/react": "*"
-      }
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@material-ui/types/-/types-5.1.0.tgz",
+      "integrity": "sha512-7cqRjrY50b8QzRSYyhSpx4WRw2YuO0KKIGQEVk5J8uoz2BanawykgZGoWEqKm7pVIbzFDN0SpPcVV4IhOFkl8A=="
     },
     "@material-ui/utils": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@material-ui/utils/-/utils-4.1.0.tgz",
-      "integrity": "sha512-muwmVU799tzPjzb+Q5E/CTDle0rXwkCAdvMVyU0BfbJhenkUsFmuYiCmbvMVOU1m6F1S5HWfXz8EP4pXwwAvrw==",
+      "version": "4.10.2",
+      "resolved": "https://registry.npmjs.org/@material-ui/utils/-/utils-4.10.2.tgz",
+      "integrity": "sha512-eg29v74P7W5r6a4tWWDAAfZldXIzfyO1am2fIsC39hdUUHm/33k6pGOKPbgDjg/U/4ifmgAePy/1OjkKN6rFRw==",
       "requires": {
-        "@babel/runtime": "^7.2.0",
+        "@babel/runtime": "^7.4.4",
         "prop-types": "^15.7.2",
         "react-is": "^16.8.0"
       }
@@ -1703,9 +1721,9 @@
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
     },
     "@types/prop-types": {
-      "version": "15.7.1",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.1.tgz",
-      "integrity": "sha512-CFzn9idOEpHrgdw8JsoTkaDDyRWk1jrzIV8djzcgpq0y9tG4B4lFT+Nxh52DVpDXV+n4+NPNv7M1Dj5uMp6XFg=="
+      "version": "15.7.3",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
+      "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw=="
     },
     "@types/q": {
       "version": "1.5.4",
@@ -1713,18 +1731,25 @@
       "integrity": "sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug=="
     },
     "@types/react": {
-      "version": "16.8.23",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.8.23.tgz",
-      "integrity": "sha512-abkEOIeljniUN9qB5onp++g0EY38h7atnDHxwKUFz1r3VH1+yG1OKi2sNPTyObL40goBmfKFpdii2lEzwLX1cA==",
+      "version": "16.9.53",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.53.tgz",
+      "integrity": "sha512-4nW60Sd4L7+WMXH1D6jCdVftuW7j4Za6zdp6tJ33Rqv0nk1ZAmQKML9ZLD4H0dehA3FZxXR/GM8gXplf82oNGw==",
       "requires": {
         "@types/prop-types": "*",
-        "csstype": "^2.2.0"
+        "csstype": "^3.0.2"
+      },
+      "dependencies": {
+        "csstype": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.4.tgz",
+          "integrity": "sha512-xc8DUsCLmjvCfoD7LTGE0ou2MIWLx0K9RCZwSHMOdynqRsP4MtUcLeqh1HcQ2dInwDTqn+3CE0/FZh1et+p4jA=="
+        }
       }
     },
     "@types/react-transition-group": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-2.9.2.tgz",
-      "integrity": "sha512-5Fv2DQNO+GpdPZcxp2x/OQG/H19A01WlmpjVD9cKvVFmoVLOZ9LvBgSWG6pSXIU4og5fgbvGPaCV5+VGkWAEHA==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.0.tgz",
+      "integrity": "sha512-/QfLHGpu+2fQOqQaXh8MG9q03bFENooTb/it4jr5kKaZlDQfWvjqWZg48AwzPVMBHlRuTRAY7hRHCEOXz5kV6w==",
       "requires": {
         "@types/react": "*"
       }
@@ -1974,6 +1999,11 @@
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz",
       "integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q=="
     },
+    "abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+    },
     "accepts": {
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
@@ -2096,6 +2126,11 @@
       "resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
       "integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM="
     },
+    "amdefine": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
+    },
     "ansi-colors": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.4.tgz",
@@ -2148,6 +2183,39 @@
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
       "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
     },
+    "are-we-there-yet": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
+      "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+      "requires": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^2.0.6"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -2189,6 +2257,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
       "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM="
+    },
+    "array-find-index": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
+      "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E="
     },
     "array-flatten": {
       "version": "2.1.2",
@@ -2348,6 +2421,11 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
       "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ=="
+    },
+    "async-foreach": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz",
+      "integrity": "sha1-NhIfhFwFeBct5Bmpfb6x0W7DRUI="
     },
     "async-limiter": {
       "version": "1.0.1",
@@ -2906,6 +2984,14 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
       "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ=="
     },
+    "block-stream": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+      "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+      "requires": {
+        "inherits": "~2.0.0"
+      }
+    },
     "bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -3263,6 +3349,22 @@
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
     },
+    "camelcase-keys": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+      "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
+      "requires": {
+        "camelcase": "^2.0.0",
+        "map-obj": "^1.0.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+          "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
+        }
+      }
+    },
     "caniuse-api": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-3.0.0.tgz",
@@ -3517,6 +3619,11 @@
         "q": "^1.1.2"
       }
     },
+    "code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+    },
     "collection-visit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
@@ -3690,10 +3797,10 @@
       "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.2.0.tgz",
       "integrity": "sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA=="
     },
-    "console-polyfill": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/console-polyfill/-/console-polyfill-0.1.2.tgz",
-      "integrity": "sha1-ls/tUcr3gYn2mVcubxgnHcN8DjA="
+    "console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
     },
     "constants-browserify": {
       "version": "1.0.0",
@@ -3717,15 +3824,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
       "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
-    },
-    "convert-css-length": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/convert-css-length/-/convert-css-length-2.0.0.tgz",
-      "integrity": "sha512-ygBgHNzImHJ/kjgqdzC0oaY2+EMID3s88/CZD2C9O1stM3PwsOwXzzlFTTkZy/bPZe0wjyt1UoYjilfunQGjlw==",
-      "requires": {
-        "console-polyfill": "^0.1.2",
-        "parse-unit": "^1.0.1"
-      }
     },
     "convert-source-map": {
       "version": "1.7.0",
@@ -4016,12 +4114,27 @@
       }
     },
     "css-vendor": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/css-vendor/-/css-vendor-2.0.5.tgz",
-      "integrity": "sha512-36w+4Cg0zqFIt5TAkaM3proB6XWh5kSGmbddRCPdrRLQiYNfHPTgaWPOlCrcuZIO0iAtrG+5wsHJZ6jj8AUULA==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/css-vendor/-/css-vendor-2.0.8.tgz",
+      "integrity": "sha512-x9Aq0XTInxrkuFeHKbYC7zWY8ai7qJ04Kxd9MnvbC1uO5DagxoHQjm4JvG+vCdXOoFtCjbL2XSZfxmoYa9uQVQ==",
       "requires": {
-        "@babel/runtime": "^7.3.1",
+        "@babel/runtime": "^7.8.3",
         "is-in-browser": "^1.0.2"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.12.1",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.1.tgz",
+          "integrity": "sha512-J5AIf3vPj3UwXaAzb5j1xM4WAQDX3EMgemF8rjCP3SoW09LfRKAXQKt6CoVYl230P6iWdRcBbnLDDdnqWxZSCA==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.7",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+          "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
+        }
       }
     },
     "css-what": {
@@ -4153,9 +4266,17 @@
       }
     },
     "csstype": {
-      "version": "2.6.5",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.5.tgz",
-      "integrity": "sha512-JsTaiksRsel5n7XwqPAfB0l3TFKdpjW/kgAELf9vrb5adGA7UCPLajKK5s3nFrcFm3Rkyp/Qkgl73ENc1UY3cA=="
+      "version": "2.6.13",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.13.tgz",
+      "integrity": "sha512-ul26pfSQTZW8dcOnD2iiJssfXw0gdNVX9IJDH/X3K5DGPfj+fUYe3kB+swUY6BF3oZDxaID3AJt+9/ojSAE05A=="
+    },
+    "currently-unhandled": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+      "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
+      "requires": {
+        "array-find-index": "^1.0.1"
+      }
     },
     "cyclist": {
       "version": "1.0.1",
@@ -4206,11 +4327,6 @@
         }
       }
     },
-    "debounce": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.0.tgz",
-      "integrity": "sha512-mYtLl1xfZLi1m4RtQYlZgJUNQjl4ZxVnHzIR8nLLgi4q1YT8o/WM+MK/f8yfcc9s5Ir5zRaPZyZU6xs1Syoocg=="
-    },
     "debug": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
@@ -4246,11 +4362,6 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
-    },
-    "deepmerge": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-3.3.0.tgz",
-      "integrity": "sha512-GRQOafGHwMHpjPx9iCvTgpu9NojZ49q794EEL94JVEw6VaeA8XTUyBKvAkOOjBX9oJNiV6G3P+T+tihFjo2TqA=="
     },
     "default-gateway": {
       "version": "4.2.0",
@@ -4360,6 +4471,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
+    "delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
     },
     "depd": {
       "version": "1.1.2",
@@ -4484,11 +4600,32 @@
       }
     },
     "dom-helpers": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.4.0.tgz",
-      "integrity": "sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.0.tgz",
+      "integrity": "sha512-Ru5o9+V8CpunKnz5LGgWXkmrH/20cGKwcHwS4m73zIvs54CN9epEmT/HLqFJW3kXpakAFkEdzgy1hzlJe3E4OQ==",
       "requires": {
-        "@babel/runtime": "^7.1.2"
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.12.1",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.1.tgz",
+          "integrity": "sha512-J5AIf3vPj3UwXaAzb5j1xM4WAQDX3EMgemF8rjCP3SoW09LfRKAXQKt6CoVYl230P6iWdRcBbnLDDdnqWxZSCA==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "csstype": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.4.tgz",
+          "integrity": "sha512-xc8DUsCLmjvCfoD7LTGE0ou2MIWLx0K9RCZwSHMOdynqRsP4MtUcLeqh1HcQ2dInwDTqn+3CE0/FZh1et+p4jA=="
+        },
+        "regenerator-runtime": {
+          "version": "0.13.7",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+          "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
+        }
       }
     },
     "dom-serializer": {
@@ -6004,6 +6141,17 @@
       "integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==",
       "optional": true
     },
+    "fstream": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
+      "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "inherits": "~2.0.0",
+        "mkdirp": ">=0.5 0",
+        "rimraf": "2"
+      }
+    },
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -6013,6 +6161,62 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
+    },
+    "gauge": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+      "requires": {
+        "aproba": "^1.0.3",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.0",
+        "object-assign": "^4.1.0",
+        "signal-exit": "^3.0.0",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wide-align": "^1.1.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        }
+      }
+    },
+    "gaze": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.3.tgz",
+      "integrity": "sha512-BRdNm8hbWzFzWHERTrejLqwHDfS4GibPoq5wjTPIoJHoBtKGPg3xAFfxmM+9ztbXelxcf2hwQcaz1PtmFeue8g==",
+      "requires": {
+        "globule": "^1.0.0"
+      }
     },
     "gensync": {
       "version": "1.0.0-beta.1",
@@ -6028,6 +6232,11 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.2.tgz",
       "integrity": "sha512-I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g=="
+    },
+    "get-stdin": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+      "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4="
     },
     "get-stream": {
       "version": "4.1.0",
@@ -6132,6 +6341,16 @@
         }
       }
     },
+    "globule": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/globule/-/globule-1.3.2.tgz",
+      "integrity": "sha512-7IDTQTIu2xzXkT+6mlluidnWo+BypnbSoEVVQCGfzqnl5Ik8d3e1d4wycb8Rj9tWW+Z39uPWsdlquqiqPCd/pA==",
+      "requires": {
+        "glob": "~7.1.1",
+        "lodash": "~4.17.10",
+        "minimatch": "~3.0.2"
+      }
+    },
     "graceful-fs": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
@@ -6219,6 +6438,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
       "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
+    },
+    "has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
     },
     "has-value": {
       "version": "1.0.0",
@@ -6515,9 +6739,9 @@
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM="
     },
     "hyphenate-style-name": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.3.tgz",
-      "integrity": "sha512-EcuixamT82oplpoJ2XU4pDtKGWQ7b00CD9f1ug9IaQ3p1bkHMiKCZ9ut9QDI6qsa6cpUuB+A/I+zLtdNK4n2DQ=="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz",
+      "integrity": "sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ=="
     },
     "iconv-lite": {
       "version": "0.4.24",
@@ -6601,6 +6825,11 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
+    },
+    "in-publish": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/in-publish/-/in-publish-2.0.1.tgz",
+      "integrity": "sha512-oDM0kUSNFC31ShNxHKUyfZKy8ZeXZBWMjMdZHKLOk13uvT27VTL/QzRGfRUcevJhpkZAvlhPYuXkF7eNWrtyxQ=="
     },
     "indent-string": {
       "version": "4.0.0",
@@ -6883,6 +7112,11 @@
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
     },
+    "is-finite": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.1.0.tgz",
+      "integrity": "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w=="
+    },
     "is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -7011,6 +7245,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+    },
+    "is-utf8": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
     },
     "is-windows": {
       "version": "1.0.2",
@@ -7333,7 +7572,10 @@
           "version": "1.2.13",
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
-          "optional": true
+          "optional": true,
+          "requires": {
+            "nan": "^2.12.1"
+          }
         }
       }
     },
@@ -7630,6 +7872,11 @@
         }
       }
     },
+    "js-base64": {
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.6.4.tgz",
+      "integrity": "sha512-pZe//GGmwJndub7ZghVHz7vjb2LgC1m8B07Au3eYqeqv9emhESByMXxaEgkUkEqJe87oBbSniGYoQNIBklc7IQ=="
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -7770,79 +8017,88 @@
       }
     },
     "jss": {
-      "version": "10.0.0-alpha.17",
-      "resolved": "https://registry.npmjs.org/jss/-/jss-10.0.0-alpha.17.tgz",
-      "integrity": "sha512-egGIUg+YRu0+U+XXlD0gmVtU/gW5sn7+qmDv7opwK5s8emZBE/VoN55X6CaMrAa0kLeGMldnI43KOWea6M9/mA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/jss/-/jss-10.4.0.tgz",
+      "integrity": "sha512-l7EwdwhsDishXzqTc3lbsbyZ83tlUl5L/Hb16pHCvZliA9lRDdNBZmHzeJHP0sxqD0t1mrMmMR8XroR12JBYzw==",
       "requires": {
         "@babel/runtime": "^7.3.1",
+        "csstype": "^3.0.2",
         "is-in-browser": "^1.1.3",
         "tiny-warning": "^1.0.2"
+      },
+      "dependencies": {
+        "csstype": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.4.tgz",
+          "integrity": "sha512-xc8DUsCLmjvCfoD7LTGE0ou2MIWLx0K9RCZwSHMOdynqRsP4MtUcLeqh1HcQ2dInwDTqn+3CE0/FZh1et+p4jA=="
+        }
       }
     },
     "jss-plugin-camel-case": {
-      "version": "10.0.0-alpha.17",
-      "resolved": "https://registry.npmjs.org/jss-plugin-camel-case/-/jss-plugin-camel-case-10.0.0-alpha.17.tgz",
-      "integrity": "sha512-aPY4kr6MwliH7KToLRzeSk1NxXUo9n7MQsAa0Hghwj01x9UnMkDkGAKENMKUtPjGkQZfiJpB9tTLFrSJ/6VrIQ==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-camel-case/-/jss-plugin-camel-case-10.4.0.tgz",
+      "integrity": "sha512-9oDjsQ/AgdBbMyRjc06Kl3P8lDCSEts2vYZiPZfGAxbGCegqE4RnMob3mDaBby5H9vL9gWmyyImhLRWqIkRUCw==",
       "requires": {
         "@babel/runtime": "^7.3.1",
         "hyphenate-style-name": "^1.0.3",
-        "jss": "10.0.0-alpha.17"
+        "jss": "10.4.0"
       }
     },
     "jss-plugin-default-unit": {
-      "version": "10.0.0-alpha.17",
-      "resolved": "https://registry.npmjs.org/jss-plugin-default-unit/-/jss-plugin-default-unit-10.0.0-alpha.17.tgz",
-      "integrity": "sha512-KQgiXczvzJ9AlFdD8NS7FZLub0NSctSrCA9Yi/GqdsfJg4ZCriU4DzIybCZBHCi/INFGJmLIESYWSxnuhAzgSQ==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-default-unit/-/jss-plugin-default-unit-10.4.0.tgz",
+      "integrity": "sha512-BYJ+Y3RUYiMEgmlcYMLqwbA49DcSWsGgHpVmEEllTC8MK5iJ7++pT9TnKkKBnNZZxTV75ycyFCR5xeLSOzVm4A==",
       "requires": {
         "@babel/runtime": "^7.3.1",
-        "jss": "10.0.0-alpha.17"
+        "jss": "10.4.0"
       }
     },
     "jss-plugin-global": {
-      "version": "10.0.0-alpha.17",
-      "resolved": "https://registry.npmjs.org/jss-plugin-global/-/jss-plugin-global-10.0.0-alpha.17.tgz",
-      "integrity": "sha512-WYxiwwI+CLk0ozW8loeceqXBAZXBMsLBEZeRwVf9WX+FljdJkGwVZpRCk6LBX4aXnqAGyKqCxIAIJ3KP2yBdEg==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-global/-/jss-plugin-global-10.4.0.tgz",
+      "integrity": "sha512-b8IHMJUmv29cidt3nI4bUI1+Mo5RZE37kqthaFpmxf5K7r2aAegGliAw4hXvA70ca6ckAoXMUl4SN/zxiRcRag==",
       "requires": {
         "@babel/runtime": "^7.3.1",
-        "jss": "10.0.0-alpha.17"
+        "jss": "10.4.0"
       }
     },
     "jss-plugin-nested": {
-      "version": "10.0.0-alpha.17",
-      "resolved": "https://registry.npmjs.org/jss-plugin-nested/-/jss-plugin-nested-10.0.0-alpha.17.tgz",
-      "integrity": "sha512-onpFqv904KCujryf2t6IIV1/QoB7cSF7ojrd4UujcN5TPvYOvXF5bchi7jnHG5U0SLlRSDGMLJ9fhtoCknhEbw==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-nested/-/jss-plugin-nested-10.4.0.tgz",
+      "integrity": "sha512-cKgpeHIxAP0ygeWh+drpLbrxFiak6zzJ2toVRi/NmHbpkNaLjTLgePmOz5+67ln3qzJiPdXXJB1tbOyYKAP4Pw==",
       "requires": {
         "@babel/runtime": "^7.3.1",
-        "jss": "10.0.0-alpha.17",
+        "jss": "10.4.0",
         "tiny-warning": "^1.0.2"
       }
     },
     "jss-plugin-props-sort": {
-      "version": "10.0.0-alpha.17",
-      "resolved": "https://registry.npmjs.org/jss-plugin-props-sort/-/jss-plugin-props-sort-10.0.0-alpha.17.tgz",
-      "integrity": "sha512-KnbyrxCbtQTqpDx2mSZU/r/E5QnDPIVfIxRi8K+W/q4gZpomBvqWC+xgvAk9hbpmA6QBoQaOilV8o12w2IZ6fg==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-props-sort/-/jss-plugin-props-sort-10.4.0.tgz",
+      "integrity": "sha512-j/t0R40/2fp+Nzt6GgHeUFnHVY2kPGF5drUVlgkcwYoHCgtBDOhTTsOfdaQFW6sHWfoQYgnGV4CXdjlPiRrzwA==",
       "requires": {
         "@babel/runtime": "^7.3.1",
-        "jss": "10.0.0-alpha.17"
+        "jss": "10.4.0"
       }
     },
     "jss-plugin-rule-value-function": {
-      "version": "10.0.0-alpha.17",
-      "resolved": "https://registry.npmjs.org/jss-plugin-rule-value-function/-/jss-plugin-rule-value-function-10.0.0-alpha.17.tgz",
-      "integrity": "sha512-8AuJB44Q+ehfkWVRi2XlRbUf6SrLmrHTa5EXd6dgQRCCRuvGmqX8Dl4fZvNeKRFjTLPZgzg9+31rqeOMhKa2vA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-rule-value-function/-/jss-plugin-rule-value-function-10.4.0.tgz",
+      "integrity": "sha512-w8504Cdfu66+0SJoLkr6GUQlEb8keHg8ymtJXdVHWh0YvFxDG2l/nS93SI5Gfx0fV29dO6yUugXnKzDFJxrdFQ==",
       "requires": {
         "@babel/runtime": "^7.3.1",
-        "jss": "10.0.0-alpha.17"
+        "jss": "10.4.0",
+        "tiny-warning": "^1.0.2"
       }
     },
     "jss-plugin-vendor-prefixer": {
-      "version": "10.0.0-alpha.17",
-      "resolved": "https://registry.npmjs.org/jss-plugin-vendor-prefixer/-/jss-plugin-vendor-prefixer-10.0.0-alpha.17.tgz",
-      "integrity": "sha512-wDq9EL0QaoMGSGifPEBb+/SA9LBcqPEW0jpL9ht+Z2t+lV7NNz0j7uCEOuE6FvNWqHzUKTsiATs1rTHPkzNBEQ==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-vendor-prefixer/-/jss-plugin-vendor-prefixer-10.4.0.tgz",
+      "integrity": "sha512-DpF+/a+GU8hMh/948sBGnKSNfKkoHg2p9aRFUmyoyxgKjOeH9n74Ht3Yt8lOgdZsuWNJbPrvaa3U4PXKwxVpTQ==",
       "requires": {
         "@babel/runtime": "^7.3.1",
-        "css-vendor": "^2.0.1",
-        "jss": "10.0.0-alpha.17"
+        "css-vendor": "^2.0.8",
+        "jss": "10.4.0"
       }
     },
     "jsx-ast-utils": {
@@ -8064,6 +8320,15 @@
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
     },
+    "loud-rejection": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
+      "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
+      "requires": {
+        "currently-unhandled": "^0.4.1",
+        "signal-exit": "^3.0.0"
+      }
+    },
     "lower-case": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.1.tgz",
@@ -8126,6 +8391,11 @@
       "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
       "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
     },
+    "map-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+      "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
+    },
     "map-visit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
@@ -8183,6 +8453,104 @@
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "requires": {
             "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
+    "meow": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+      "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
+      "requires": {
+        "camelcase-keys": "^2.0.0",
+        "decamelize": "^1.1.2",
+        "loud-rejection": "^1.0.0",
+        "map-obj": "^1.0.1",
+        "minimist": "^1.1.3",
+        "normalize-package-data": "^2.3.4",
+        "object-assign": "^4.0.1",
+        "read-pkg-up": "^1.0.1",
+        "redent": "^1.0.0",
+        "trim-newlines": "^1.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+          "requires": {
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "load-json-file": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0",
+            "strip-bom": "^2.0.0"
+          }
+        },
+        "parse-json": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+          "requires": {
+            "error-ex": "^1.2.0"
+          }
+        },
+        "path-exists": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+          "requires": {
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "path-type": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+        },
+        "read-pkg": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+          "requires": {
+            "load-json-file": "^1.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^1.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+          "requires": {
+            "find-up": "^1.0.0",
+            "read-pkg": "^1.0.0"
+          }
+        },
+        "strip-bom": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "requires": {
+            "is-utf8": "^0.2.0"
           }
         }
       }
@@ -8473,6 +8841,11 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
     },
+    "nan": {
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ=="
+    },
     "nanomatch": {
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
@@ -8536,6 +8909,32 @@
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
       "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA=="
+    },
+    "node-gyp": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.8.0.tgz",
+      "integrity": "sha512-3g8lYefrRRzvGeSowdJKAKyks8oUpLEd/DyPV4eMhVlhJ0aNaZqIrNUIPuEWWTAoPqyFkfGrM67MC69baqn6vA==",
+      "requires": {
+        "fstream": "^1.0.0",
+        "glob": "^7.0.3",
+        "graceful-fs": "^4.1.2",
+        "mkdirp": "^0.5.0",
+        "nopt": "2 || 3",
+        "npmlog": "0 || 1 || 2 || 3 || 4",
+        "osenv": "0",
+        "request": "^2.87.0",
+        "rimraf": "2",
+        "semver": "~5.3.0",
+        "tar": "^2.0.0",
+        "which": "1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
+        }
+      }
     },
     "node-int64": {
       "version": "0.4.0",
@@ -8647,6 +9046,98 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.63.tgz",
       "integrity": "sha512-ukW3iCfQaoxJkSPN+iK7KznTeqDGVJatAEuXsJERYHa9tn/KaT5lBdIyxQjLEVTzSkyjJEuQ17/vaEjrOauDkg=="
     },
+    "node-sass": {
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.14.1.tgz",
+      "integrity": "sha512-sjCuOlvGyCJS40R8BscF5vhVlQjNN069NtQ1gSxyK1u9iqvn6tf7O1R4GNowVZfiZUCRt5MmMs1xd+4V/7Yr0g==",
+      "requires": {
+        "async-foreach": "^0.1.3",
+        "chalk": "^1.1.1",
+        "cross-spawn": "^3.0.0",
+        "gaze": "^1.0.0",
+        "get-stdin": "^4.0.1",
+        "glob": "^7.0.3",
+        "in-publish": "^2.0.0",
+        "lodash": "^4.17.15",
+        "meow": "^3.7.0",
+        "mkdirp": "^0.5.1",
+        "nan": "^2.13.2",
+        "node-gyp": "^3.8.0",
+        "npmlog": "^4.0.0",
+        "request": "^2.88.0",
+        "sass-graph": "2.2.5",
+        "stdout-stream": "^1.4.0",
+        "true-case-path": "^1.0.2"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "cross-spawn": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-3.0.1.tgz",
+          "integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
+          "requires": {
+            "lru-cache": "^4.0.1",
+            "which": "^1.2.9"
+          }
+        },
+        "lru-cache": {
+          "version": "4.1.5",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+          "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+          "requires": {
+            "pseudomap": "^1.0.2",
+            "yallist": "^2.1.2"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+        },
+        "yallist": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+        }
+      }
+    },
+    "nopt": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+      "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+      "requires": {
+        "abbrev": "1"
+      }
+    },
     "normalize-package-data": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
@@ -8678,11 +9169,6 @@
       "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
       "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI="
     },
-    "normalize-scroll-left": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/normalize-scroll-left/-/normalize-scroll-left-0.2.0.tgz",
-      "integrity": "sha512-t5oCENZJl8TGusJKoCJm7+asaSsPuNmK6+iEjrZ5TyBj2f02brCRsd4c83hwtu+e5d4LCSBZ0uoDlMjBo+A8yA=="
-    },
     "normalize-url": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.9.1.tgz",
@@ -8702,6 +9188,17 @@
         "path-key": "^2.0.0"
       }
     },
+    "npmlog": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+      "requires": {
+        "are-we-there-yet": "~1.1.2",
+        "console-control-strings": "~1.1.0",
+        "gauge": "~2.7.3",
+        "set-blocking": "~2.0.0"
+      }
+    },
     "nth-check": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
@@ -8714,6 +9211,11 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
       "integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4="
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
     },
     "nwsapi": {
       "version": "2.2.0",
@@ -9023,10 +9525,24 @@
       "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
       "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc="
     },
+    "os-homedir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+    },
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+    },
+    "osenv": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+      "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+      "requires": {
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.0"
+      }
     },
     "p-each-series": {
       "version": "1.0.0",
@@ -9166,11 +9682,6 @@
         "error-ex": "^1.3.1",
         "json-parse-better-errors": "^1.0.1"
       }
-    },
-    "parse-unit": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/parse-unit/-/parse-unit-1.0.1.tgz",
-      "integrity": "sha1-fhu21b7zh0wo45JSaiVBFwKR7s8="
     },
     "parse5": {
       "version": "4.0.0",
@@ -9322,9 +9833,9 @@
       }
     },
     "popper.js": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.15.0.tgz",
-      "integrity": "sha512-w010cY1oCUmI+9KwwlWki+r5jxKfTFDVoadl7MSrIujHU5MJ5OR6HTDj6Xo8aoR/QsA56x8jKjA59qGH4ELtrA=="
+      "version": "1.16.1-lts",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1-lts.tgz",
+      "integrity": "sha512-Kjw8nKRl1m+VrSFCoVGPph93W/qrSO7ZkqPpTf7F4bk/sqcfWK019dWBUpE/fBOsOQY1dks/Bmcbfn1heM/IsA=="
     },
     "portfinder": {
       "version": "1.0.28",
@@ -10380,6 +10891,11 @@
       "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
       "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
     },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+    },
     "psl": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
@@ -10770,16 +11286,6 @@
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.7.tgz",
       "integrity": "sha512-TAv1KJFh3RhqxNvhzxj6LeT5NWklP6rDr2a0jaTfsZ5wSZWHOGeqQyejUp3xxLfPt2UpyJEcVQB/zyPcmonNFA=="
     },
-    "react-event-listener": {
-      "version": "0.6.6",
-      "resolved": "https://registry.npmjs.org/react-event-listener/-/react-event-listener-0.6.6.tgz",
-      "integrity": "sha512-+hCNqfy7o9wvO6UgjqFmBzARJS7qrNoda0VqzvOuioEpoEXKutiKuv92dSz6kP7rYLmyHPyYNLesi5t/aH1gfw==",
-      "requires": {
-        "@babel/runtime": "^7.2.0",
-        "prop-types": "^15.6.0",
-        "warning": "^4.0.1"
-      }
-    },
     "react-is": {
       "version": "16.8.6",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
@@ -10892,23 +11398,28 @@
       }
     },
     "react-transition-group": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.2.1.tgz",
-      "integrity": "sha512-IXrPr93VzCPupwm2O6n6C2kJIofJ/Rp5Ltihhm9UfE8lkuVX2ng/SUUl/oWjblybK9Fq2Io7LGa6maVqPB762Q==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.1.tgz",
+      "integrity": "sha512-Djqr7OQ2aPUiYurhPalTrVy9ddmFCCzwhqQmtN+J3+3DzLO209Fdr70QrN8Z3DsglWql6iY1lDWAfpFiBtuKGw==",
       "requires": {
-        "@babel/runtime": "^7.4.5",
-        "dom-helpers": "^3.4.0",
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
         "loose-envify": "^1.4.0",
         "prop-types": "^15.6.2"
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.5.0",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.0.tgz",
-          "integrity": "sha512-2xsuyZ0R0RBFwjgae5NpXk8FcfH4qovj5cEM5VEeB7KXnKqzaisIu2HSV/mCEISolJJuR4wkViUGYujA8MH9tw==",
+          "version": "7.12.1",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.1.tgz",
+          "integrity": "sha512-J5AIf3vPj3UwXaAzb5j1xM4WAQDX3EMgemF8rjCP3SoW09LfRKAXQKt6CoVYl230P6iWdRcBbnLDDdnqWxZSCA==",
           "requires": {
-            "regenerator-runtime": "^0.13.2"
+            "regenerator-runtime": "^0.13.4"
           }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.7",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+          "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
         }
       }
     },
@@ -10963,6 +11474,25 @@
       "integrity": "sha512-nRCcW9Sj7NuZwa2XvH9co8NPeXUBhZP7CRKJtU+cS6PW9FpCIFoI5ib0NT1ZrbNuPoRy0ylyCaUL8Gih4LSyFg==",
       "requires": {
         "minimatch": "3.0.4"
+      }
+    },
+    "redent": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+      "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
+      "requires": {
+        "indent-string": "^2.1.0",
+        "strip-indent": "^1.0.1"
+      },
+      "dependencies": {
+        "indent-string": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+          "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
+          "requires": {
+            "repeating": "^2.0.0"
+          }
+        }
       }
     },
     "regenerate": {
@@ -11158,6 +11688,14 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+    },
+    "repeating": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+      "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+      "requires": {
+        "is-finite": "^1.0.0"
+      }
     },
     "request": {
       "version": "2.88.2",
@@ -11447,6 +11985,17 @@
       "resolved": "https://registry.npmjs.org/sanitize.css/-/sanitize.css-10.0.0.tgz",
       "integrity": "sha512-vTxrZz4dX5W86M6oVWVdOVe72ZiPs41Oi7Z6Km4W5Turyz28mrXSJhhEBZoRtzJWIv3833WKVwLSDWWkEfupMg=="
     },
+    "sass-graph": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.2.5.tgz",
+      "integrity": "sha512-VFWDAHOe6mRuT4mZRd4eKE+d8Uedrk6Xnh7Sh9b4NGufQLQjOrvf/MQoOdx+0s92L89FeyUUNfU597j/3uNpag==",
+      "requires": {
+        "glob": "^7.0.0",
+        "lodash": "^4.0.0",
+        "scss-tokenizer": "^0.2.3",
+        "yargs": "^13.3.2"
+      }
+    },
     "sass-loader": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-8.0.2.tgz",
@@ -11514,6 +12063,25 @@
         "@types/json-schema": "^7.0.5",
         "ajv": "^6.12.4",
         "ajv-keywords": "^3.5.2"
+      }
+    },
+    "scss-tokenizer": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz",
+      "integrity": "sha1-jrBtualyMzOCTT9VMGQRSYR85dE=",
+      "requires": {
+        "js-base64": "^2.1.8",
+        "source-map": "^0.4.2"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.4.4",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+          "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+          "requires": {
+            "amdefine": ">=0.0.4"
+          }
+        }
       }
     },
     "select-hose": {
@@ -12122,6 +12690,38 @@
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
       "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
     },
+    "stdout-stream": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/stdout-stream/-/stdout-stream-1.4.1.tgz",
+      "integrity": "sha512-j4emi03KXqJWcIeF8eIXkjMFN1Cmb8gUlDYGeBALLPo5qdyTfA9bOtl8m33lRoC+vFMkP3gl0WsDr6+gzxbbTA==",
+      "requires": {
+        "readable-stream": "^2.0.1"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
     "stealthy-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
@@ -12416,6 +13016,14 @@
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
     },
+    "strip-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
+      "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
+      "requires": {
+        "get-stdin": "^4.0.1"
+      }
+    },
     "strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -12539,6 +13147,16 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
       "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA=="
+    },
+    "tar": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
+      "integrity": "sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==",
+      "requires": {
+        "block-stream": "*",
+        "fstream": "^1.0.12",
+        "inherits": "2"
+      }
     },
     "terser": {
       "version": "4.8.0",
@@ -12816,6 +13434,19 @@
       "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
       "requires": {
         "punycode": "^2.1.0"
+      }
+    },
+    "trim-newlines": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
+      "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM="
+    },
+    "true-case-path": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/true-case-path/-/true-case-path-1.0.3.tgz",
+      "integrity": "sha512-m6s2OdQe5wgpFMC+pAJ+q9djG82O2jcHPOI6RNg1yy9rCYR+WD6Nbpl32fDpfC56nirdRy+opFa/Vk7HYhqaew==",
+      "requires": {
+        "glob": "^7.1.2"
       }
     },
     "ts-pnp": {
@@ -13192,14 +13823,6 @@
         "makeerror": "1.0.x"
       }
     },
-    "warning": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
-      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
-      "requires": {
-        "loose-envify": "^1.0.0"
-      }
-    },
     "watchpack": {
       "version": "1.7.4",
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.7.4.tgz",
@@ -13250,7 +13873,10 @@
           "version": "1.2.13",
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
-          "optional": true
+          "optional": true,
+          "requires": {
+            "nan": "^2.12.1"
+          }
         },
         "glob-parent": {
           "version": "3.1.0",
@@ -13530,7 +14156,10 @@
           "version": "1.2.13",
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
-          "optional": true
+          "optional": true,
+          "requires": {
+            "nan": "^2.12.1"
+          }
         },
         "glob-parent": {
           "version": "3.1.0",
@@ -13738,6 +14367,43 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+    },
+    "wide-align": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+      "requires": {
+        "string-width": "^1.0.2 || 2"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        }
+      }
     },
     "word-wrap": {
       "version": "1.2.3",

--- a/client/package.json
+++ b/client/package.json
@@ -3,15 +3,15 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@material-ui/core": "^4.1.3",
+    "@material-ui/core": "^4.9.10",
     "node-sass": "^4.14.1",
     "@material-ui/icons": "^4.9.1",
+    "@material-ui/lab": "4.0.0-alpha.56",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-router-dom": "^5.0.1",
     "react-scripts": "^3.4.3"
   },
-  "proxy": "http://localhost:5000",
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -7,6 +7,7 @@ import Login from "./components/Login";
 import SignUp from "./components/SignUp";
 import ProtectedRoute from "./components/ProtectedRoute";
 import Dashboard from "./pages/Dashboard";
+import LandingPage from "./pages/LandingPage";
 import { theme } from "./themes/theme";
 import { UserStore } from "./contexts/UserContext";
 
@@ -19,6 +20,7 @@ function App() {
             <BrowserRouter>
               <Route path="/" exact component={Login} />
               <Route path="/signup" exact component={SignUp} />
+              <Route path="/landing" exact component={LandingPage} />
               <ProtectedRoute exact path="/dashboard" component={Dashboard} />
             </BrowserRouter>
           </UserStore>

--- a/client/src/components/Login.js
+++ b/client/src/components/Login.js
@@ -1,13 +1,9 @@
 import React, { useState, useContext } from "react";
 import { Link, withRouter } from "react-router-dom";
 import { makeStyles } from "@material-ui/core/styles";
-import { Button, TextField, Box, Snackbar } from "@material-ui/core";
-import MuiAlert from "@material-ui/lab/alert";
+import { Button, TextField, Box } from "@material-ui/core";
 import UserContext from "../contexts/UserContext";
-
-function Alert(props) {
-  return <MuiAlert elevation={6} variant="filled" {...props} />;
-}
+import WarningSnackbar from "./WarningSnackbar";
 
 const useStyles = makeStyles((theme) => ({
   login: {
@@ -68,11 +64,9 @@ function Login(props) {
   const [openSnack, setOpenSnack] = useState(false);
   const [snackText, setSnackText] = useState("");
   const value = useContext(UserContext);
-  const vertical = "top";
-  const horizontal = "center";
 
-  const handleSnack = (props) => {
-    setSnackText(props);
+  const handleSnack = (message) => {
+    setSnackText(message);
     setOpenSnack(true);
   };
 
@@ -99,17 +93,13 @@ function Login(props) {
       .then((response) => response.json())
       .then(function (response) {
         if (response.status === "success") {
-          console.log("Success:", email);
           const loginSuccess = value.handleLogin(email, password);
           if (loginSuccess) props.history.push("/dashboard");
         } else {
           handleSnack(response.message);
-          console.log(response.message);
         }
       })
-      .catch((error) => {
-        console.error("Error:", error);
-      });
+      .catch(() => {});
   };
 
   return (
@@ -152,16 +142,11 @@ function Login(props) {
             Create an account
           </Link>
         </Box>
-        <Snackbar
-          open={openSnack}
-          autoHideDuration={6000}
-          onClose={handleCloseSnack}
-          anchorOrigin={{ vertical, horizontal }}
-        >
-          <Alert onClose={handleCloseSnack} severity="error">
-            {snackText}
-          </Alert>
-        </Snackbar>
+        <WarningSnackbar
+          openSnack={openSnack}
+          handleCloseSnack={handleCloseSnack}
+          snackText={snackText}
+        />
       </Box>
     </section>
   );

--- a/client/src/components/Login.js
+++ b/client/src/components/Login.js
@@ -80,26 +80,9 @@ function Login(props) {
 
   const handleLogin = async (e) => {
     e.preventDefault();
-    fetch("/auth/login", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        email: email,
-        password: password,
-      }),
-    })
-      .then((response) => response.json())
-      .then(function (response) {
-        if (response.status === "success") {
-          const loginSuccess = value.handleLogin(email, password);
-          if (loginSuccess) props.history.push("/dashboard");
-        } else {
-          handleSnack(response.message);
-        }
-      })
-      .catch(() => {});
+    const response = await value.handleLogin(email, password);
+    if (response.status === "success") props.history.push("/dashboard");
+    else handleSnack(response.message);
   };
 
   return (

--- a/client/src/components/SignUp.js
+++ b/client/src/components/SignUp.js
@@ -1,7 +1,13 @@
-import React, { useState } from "react";
+import React, { useState, useContext } from "react";
 import { Link } from "react-router-dom";
 import { makeStyles } from "@material-ui/core/styles";
-import { Button, TextField, Box } from "@material-ui/core";
+import { Button, TextField, Box, Snackbar } from "@material-ui/core";
+import MuiAlert from "@material-ui/lab/alert";
+import UserContext from "../contexts/UserContext";
+
+function Alert(props) {
+  return <MuiAlert elevation={6} variant="filled" {...props} />;
+}
 
 const useStyles = makeStyles((theme) => ({
   login: {
@@ -59,6 +65,22 @@ function SignUp(props) {
   const [password, setPassword] = useState("");
   const [confirm, setConfirm] = useState("");
   const [errors, setErrors] = useState({});
+  const [openSnack, setOpenSnack] = useState(false);
+  const [snackText, setSnackText] = useState("");
+  const value = useContext(UserContext);
+
+  const handleSnack = (props) => {
+    setSnackText(props);
+    setOpenSnack(true);
+  };
+
+  const handleCloseSnack = (event, reason) => {
+    if (reason === "clickaway") {
+      return;
+    }
+
+    setOpenSnack(false);
+  };
 
   const validations = () => {
     const errorsCopy = { ...errors };
@@ -72,7 +94,7 @@ function SignUp(props) {
     return Object.values(errorsCopy).every((field) => field === "");
   };
 
-  const handleClick = (e) => {
+  const handleClick = async (e) => {
     e.preventDefault();
     if (validations()) {
       fetch("/auth/register", {
@@ -91,10 +113,10 @@ function SignUp(props) {
         .then(function (response) {
           if (response.status === "success") {
             console.log("Success:", email);
-            window.alert(response.message); // Replace with snackbar.
-            props.history.push("/dashboard");
+            const loginSuccess = value.handleLogin(email, password);
+            if (loginSuccess) props.history.push("/dashboard");
           } else {
-            window.alert(response.message); // Replace with snackbar.
+            handleSnack(response.message);
             console.log(response.message);
           }
         })
@@ -172,6 +194,16 @@ function SignUp(props) {
             Login
           </Link>
         </Box>
+        <Snackbar
+          open={openSnack}
+          autoHideDuration={6000}
+          onClose={handleCloseSnack}
+        >
+          <Alert onClose={handleCloseSnack} severity="error">
+            {snackText}
+          </Alert>
+        </Snackbar>
+        ;
       </Box>
     </section>
   );

--- a/client/src/components/SignUp.js
+++ b/client/src/components/SignUp.js
@@ -124,28 +124,9 @@ function SignUp(props) {
   const handleSignup = async (e) => {
     e.preventDefault();
     if (validations()) {
-      fetch("/auth/register", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          name: name,
-          email: email,
-          password: password,
-          confirm: confirm,
-        }),
-      })
-        .then((response) => response.json())
-        .then(function (response) {
-          if (response.status === "success") {
-            const loginSuccess = value.handleLogin(email, password);
-            if (loginSuccess) props.history.push("/dashboard");
-          } else {
-            handleSnack(response.message);
-          }
-        })
-        .catch(() => {});
+      const response = await value.handleSignup(name, email, password, confirm);
+      if (response.status === "success") props.history.push("/dashboard");
+      else handleSnack(response.message);
     }
   };
 

--- a/client/src/components/SignUp.js
+++ b/client/src/components/SignUp.js
@@ -30,8 +30,9 @@ const ErrorTooltip = withStyles((theme) => ({
 
 const useStyles = makeStyles((theme) => ({
   signup: {
-    maxWidth: "1200px",
+    width: "100vw",
     margin: "0 auto",
+    minHeight: "100vh",
     padding: "50px",
     backgroundColor: "#44475ab9",
   },

--- a/client/src/components/SignUp.js
+++ b/client/src/components/SignUp.js
@@ -106,10 +106,6 @@ function SignUp(props) {
 
   const validations = () => {
     const errorsCopy = { ...errors };
-    errorsCopy.name = name ? "" : "This field is required.";
-    errorsCopy.email = /.+@.+\..+/.test(email) ? "" : "Email is not valid.";
-    errorsCopy.password =
-      password.length > 5 ? "" : "Password must be at least six characters.";
     errorsCopy.confirm = password === confirm ? "" : "Passwords must match.";
     if (errorsCopy.confirm) {
       handleOpenTooltip();
@@ -143,7 +139,6 @@ function SignUp(props) {
             fullWidth
             required
             type="text"
-            error={!!errors.name}
             onChange={(e) => setName(e.target.value)}
           />
           <label>Your email address:</label>
@@ -183,7 +178,7 @@ function SignUp(props) {
               fullWidth
               required
               type="password"
-              error={!!errors.confirm}
+              error={Boolean(errors.confirm)}
               onChange={(e) => setConfirm(e.target.value)}
             />
           </ErrorTooltip>

--- a/client/src/components/SignUp.js
+++ b/client/src/components/SignUp.js
@@ -87,6 +87,8 @@ function SignUp(props) {
   const [openSnack, setOpenSnack] = useState(false);
   const [snackText, setSnackText] = useState("");
   const value = useContext(UserContext);
+  const vertical = "top";
+  const horizontal = "center";
 
   function sleep(time) {
     return new Promise((resolve) => setTimeout(resolve, time));
@@ -246,6 +248,7 @@ function SignUp(props) {
           open={openSnack}
           autoHideDuration={6000}
           onClose={handleCloseSnack}
+          anchorOrigin={{ vertical, horizontal }}
         >
           <Alert onClose={handleCloseSnack} severity="error">
             {snackText}

--- a/client/src/components/SignUp.js
+++ b/client/src/components/SignUp.js
@@ -92,8 +92,8 @@ function SignUp(props) {
     setOpenTooltip(false);
   };
 
-  const handleSnack = (props) => {
-    setSnackText(props);
+  const handleSnack = (message) => {
+    setSnackText(message);
     setOpenSnack(true);
   };
 

--- a/client/src/components/SignUp.js
+++ b/client/src/components/SignUp.js
@@ -1,7 +1,7 @@
 import React, { useState, useContext } from "react";
 import { Link } from "react-router-dom";
 import { makeStyles } from "@material-ui/core/styles";
-import { Button, TextField, Box, Snackbar } from "@material-ui/core";
+import { Button, TextField, Box, Snackbar, Tooltip } from "@material-ui/core";
 import MuiAlert from "@material-ui/lab/alert";
 import UserContext from "../contexts/UserContext";
 
@@ -34,7 +34,7 @@ const useStyles = makeStyles((theme) => ({
   textField: {
     display: "block",
     width: "80%",
-    margin: "5px auto 15px auto",
+    margin: "5px auto 40px auto",
     textAlign: "center",
     backgroundColor: "white",
   },
@@ -65,9 +65,14 @@ function SignUp(props) {
   const [password, setPassword] = useState("");
   const [confirm, setConfirm] = useState("");
   const [errors, setErrors] = useState({});
+  const [openNameTooltip, setOpenNameTooltip] = useState(false);
   const [openSnack, setOpenSnack] = useState(false);
   const [snackText, setSnackText] = useState("");
   const value = useContext(UserContext);
+
+  const handleNameTooltip = () => {
+    setOpenNameTooltip(true);
+  };
 
   const handleSnack = (props) => {
     setSnackText(props);
@@ -85,7 +90,10 @@ function SignUp(props) {
   const validations = () => {
     const errorsCopy = { ...errors };
     errorsCopy.name = name ? "" : "This field is required.";
-    errorsCopy.email = /.+@.+..+/.test(email) ? "" : "Email is not valid.";
+    if (errorsCopy.name) {
+      setOpenNameTooltip(true);
+    }
+    errorsCopy.email = /.+@.+\..+/.test(email) ? "" : "Email is not valid.";
     errorsCopy.password =
       password.length > 5 ? "" : "Password must be at least six characters.";
     errorsCopy.confirm = password === confirm ? "" : "Passwords must match.";
@@ -132,17 +140,25 @@ function SignUp(props) {
         <form>
           <h2 className={classes.h2}>Sign up</h2>
           <label>Your Name</label>
-          <TextField
-            className={classes.textField}
-            variant="outlined"
-            label="name"
-            fullWidth
-            required
-            type="text"
-            error={!!errors.name}
-            helperText={errors.name}
-            onChange={(e) => setName(e.target.value)}
-          />
+          <Tooltip
+            open={openNameTooltip}
+            title={errors.name}
+            arrow
+            disableHoverListener
+            disableTouchListener
+            disableFocusListener
+          >
+            <TextField
+              className={classes.textField}
+              variant="outlined"
+              label="name"
+              fullWidth
+              required
+              type="text"
+              error={!!errors.name}
+              onChange={(e) => setName(e.target.value)}
+            />
+          </Tooltip>
           <label>Your email address:</label>
           <TextField
             className={classes.textField}
@@ -181,9 +197,10 @@ function SignUp(props) {
           />
           <Button
             className={classes.button}
+            onClick={handleClick}
+            //type="submit"
             variant="contained"
             color="secondary"
-            onClick={handleClick}
           >
             Sign up
           </Button>
@@ -203,7 +220,6 @@ function SignUp(props) {
             {snackText}
           </Alert>
         </Snackbar>
-        ;
       </Box>
     </section>
   );

--- a/client/src/components/SignUp.js
+++ b/client/src/components/SignUp.js
@@ -1,13 +1,32 @@
 import React, { useState, useContext } from "react";
 import { Link } from "react-router-dom";
-import { makeStyles } from "@material-ui/core/styles";
-import { Button, TextField, Box, Snackbar, Tooltip} from "@material-ui/core";
+import { makeStyles, withStyles } from "@material-ui/core/styles";
+import {
+  Button,
+  TextField,
+  Box,
+  Snackbar,
+  Tooltip,
+  Typography,
+} from "@material-ui/core";
 import MuiAlert from "@material-ui/lab/alert";
 import UserContext from "../contexts/UserContext";
 
-// function Alert(props) {
-//   return <MuiAlert elevation={6} variant="filled" {...props} />;
-// }
+function Alert(props) {
+  return <MuiAlert elevation={6} variant="filled" {...props} />;
+}
+
+const ErrorTooltip = withStyles((theme) => ({
+  arrow: {
+    color: "red",
+  },
+  tooltip: {
+    backgroundColor: "red",
+    color: "rgba(255, 255, 255, 0.87)",
+    boxShadow: theme.shadows[1],
+    fontSize: 14,
+  },
+}))(Tooltip);
 
 const useStyles = makeStyles((theme) => ({
   signup: {
@@ -64,105 +83,103 @@ function SignUp(props) {
   const [password, setPassword] = useState("");
   const [confirm, setConfirm] = useState("");
   const [errors, setErrors] = useState({});
-  // const [openNameTooltip, setOpenNameTooltip] = useState(false);
-  // const [openSnack, setOpenSnack] = useState(false);
-  // const [snackText, setSnackText] = useState("");
+  const [openTooltip, setOpenTooltip] = useState(false);
+  const [openSnack, setOpenSnack] = useState(false);
+  const [snackText, setSnackText] = useState("");
   const value = useContext(UserContext);
 
-  // const handleNameTooltip = () => {
-  //   setOpenNameTooltip(true);
-  // };
+  function sleep(time) {
+    return new Promise((resolve) => setTimeout(resolve, time));
+  }
 
-  // const handleSnack = (props) => {
-  //   setSnackText(props);
-  //   setOpenSnack(true);
-  // };
+  const handleOpenTooltip = async () => {
+    setOpenTooltip(true);
+    await sleep(6000);
+    setOpenTooltip(false);
+  };
 
-  // const handleCloseSnack = (event, reason) => {
-  //   if (reason === "clickaway") {
-  //     return;
-  //   }
+  const handleCloseTooltip = () => {
+    setOpenTooltip(false);
+  };
 
-  //   setOpenSnack(false);
-  // };
+  const handleSnack = (props) => {
+    setSnackText(props);
+    setOpenSnack(true);
+  };
 
-  // const validations = () => {
-  //   const errorsCopy = { ...errors };
-  //   errorsCopy.name = name ? "" : "This field is required.";
-  //   if (errorsCopy.name) {
-  //     setOpenNameTooltip(true);
-  //   }
-  //   errorsCopy.email = /.+@.+\..+/.test(email) ? "" : "Email is not valid.";
-  //   errorsCopy.password =
-  //     password.length > 5 ? "" : "Password must be at least six characters.";
-  //   errorsCopy.confirm = password === confirm ? "" : "Passwords must match.";
-  //   setErrors({ ...errorsCopy });
+  const handleCloseSnack = (event, reason) => {
+    if (reason === "clickaway") {
+      return;
+    }
 
-  //   return Object.values(errorsCopy).every((field) => field === "");
-  // };
+    setOpenSnack(false);
+  };
 
-  // const handleSignup = async (e) => {
-  //   e.preventDefault();
-  //   if (true) {
-  //     fetch("/auth/register", {
-  //       method: "POST",
-  //       headers: {
-  //         "Content-Type": "application/json",
-  //       },
-  //       body: JSON.stringify({
-  //         name: name,
-  //         email: email,
-  //         password: password,
-  //         confirm: confirm,
-  //       }),
-  //     })
-  //       .then((response) => response.json())
-  //       .then(function (response) {
-  //         if (response.status === "success") {
-  //           console.log("Success:", email);
-  //           const loginSuccess = value.handleLogin(email, password);
-  //           if (loginSuccess) props.history.push("/dashboard");
-  //         } else {
-  //           // handleSnack(response.message);
-  //           console.log(response.message);
-  //         }
-  //       })
-  //       .catch((error) => {
-  //         console.error("Error:", error);
-  //       });
-  //   }
-  // };
-  const handleSubmit = (e) => {
+  const validations = () => {
+    const errorsCopy = { ...errors };
+    errorsCopy.name = name ? "" : "This field is required.";
+    errorsCopy.email = /.+@.+\..+/.test(email) ? "" : "Email is not valid.";
+    errorsCopy.password =
+      password.length > 5 ? "" : "Password must be at least six characters.";
+    errorsCopy.confirm = password === confirm ? "" : "Passwords must match.";
+    if (errorsCopy.confirm) {
+      handleOpenTooltip();
+    } else {
+      handleCloseTooltip();
+    }
+    setErrors({ ...errorsCopy });
+
+    return Object.values(errorsCopy).every((field) => field === "");
+  };
+
+  const handleSignup = async (e) => {
     e.preventDefault();
-    const signupSuccess = value.handleSignup(name, email, password, confirm);
-    if (signupSuccess) props.history.push("/dashboard");
+    if (validations()) {
+      fetch("/auth/register", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          name: name,
+          email: email,
+          password: password,
+          confirm: confirm,
+        }),
+      })
+        .then((response) => response.json())
+        .then(function (response) {
+          if (response.status === "success") {
+            console.log("Success:", email);
+            const loginSuccess = value.handleLogin(email, password);
+            if (loginSuccess) props.history.push("/dashboard");
+          } else {
+            handleSnack(response.message);
+            console.log(response.message);
+          }
+        })
+        .catch((error) => {
+          console.error("Error:", error);
+        });
+    }
   };
 
   return (
     <section className={classes.signup}>
       <Box className={classes.formContainer}>
-        <form form onSubmit={handleSubmit}>
+        <form form onSubmit={handleSignup}>
           <h2 className={classes.h2}>Sign up</h2>
           <label>Your Name</label>
-          {/* <Tooltip
-            open={openNameTooltip}
-            title={errors.name}
-            arrow
-            disableHoverListener
-            disableTouchListener
-            disableFocusListener
-          > */}
-            <TextField
-              className={classes.textField}
-              variant="outlined"
-              label="name"
-              fullWidth
-              required
-              // type="text"
-              // error={!!errors.name}
-              onChange={(e) => setName(e.target.value)}
-            />
-          {/* </Tooltip> */}
+          <TextField
+            className={classes.textField}
+            variant="outlined"
+            label="name"
+            fullWidth
+            required
+            type="text"
+            error={!!errors.name}
+            onChange={(e) => setName(e.target.value)}
+          />
           <label>Your email address:</label>
           <TextField
             className={classes.textField}
@@ -189,17 +206,26 @@ function SignUp(props) {
             onChange={(e) => setPassword(e.target.value)}
           />
           <label>Confirm Password:</label>
-          <TextField
-            className={classes.textField}
-            variant="outlined"
-            label="confirm password"
-            fullWidth
-            required
-            type="password"
-            // error={!!errors.confirm}
-            // helperText={errors.confirm}
-            onChange={(e) => setConfirm(e.target.value)}
-          />
+          <ErrorTooltip
+            open={openTooltip}
+            title={<Typography>Passwords must match.</Typography>}
+            arrow
+            disableHoverListener
+            disableTouchListener
+            disableFocusListener
+          >
+            <TextField
+              className={classes.textField}
+              variant="outlined"
+              label="confirm password"
+              fullWidth
+              required
+              type="password"
+              error={!!errors.confirm}
+              // helperText={errors.confirm}
+              onChange={(e) => setConfirm(e.target.value)}
+            />
+          </ErrorTooltip>
           <Button
             className={classes.button}
             // onClick={handleClick}
@@ -216,7 +242,7 @@ function SignUp(props) {
             Login
           </Link>
         </Box>
-        {/* <Snackbar
+        <Snackbar
           open={openSnack}
           autoHideDuration={6000}
           onClose={handleCloseSnack}
@@ -224,7 +250,7 @@ function SignUp(props) {
           <Alert onClose={handleCloseSnack} severity="error">
             {snackText}
           </Alert>
-        </Snackbar> */}
+        </Snackbar>
       </Box>
     </section>
   );

--- a/client/src/components/SignUp.js
+++ b/client/src/components/SignUp.js
@@ -92,7 +92,7 @@ function SignUp(props) {
           if (response.status === "success") {
             console.log("Success:", email);
             window.alert(response.message); // Replace with snackbar.
-            props.history.push("/");
+            props.history.push("/dashboard");
           } else {
             window.alert(response.message); // Replace with snackbar.
             console.log(response.message);

--- a/client/src/components/SignUp.js
+++ b/client/src/components/SignUp.js
@@ -1,20 +1,9 @@
 import React, { useState, useContext } from "react";
 import { Link } from "react-router-dom";
 import { makeStyles, withStyles } from "@material-ui/core/styles";
-import {
-  Button,
-  TextField,
-  Box,
-  Snackbar,
-  Tooltip,
-  Typography,
-} from "@material-ui/core";
-import MuiAlert from "@material-ui/lab/alert";
+import { Button, TextField, Box, Tooltip, Typography } from "@material-ui/core";
 import UserContext from "../contexts/UserContext";
-
-function Alert(props) {
-  return <MuiAlert elevation={6} variant="filled" {...props} />;
-}
+import WarningSnackbar from "./WarningSnackbar";
 
 const ErrorTooltip = withStyles((theme) => ({
   arrow: {
@@ -88,8 +77,6 @@ function SignUp(props) {
   const [openSnack, setOpenSnack] = useState(false);
   const [snackText, setSnackText] = useState("");
   const value = useContext(UserContext);
-  const vertical = "top";
-  const horizontal = "center";
 
   function sleep(time) {
     return new Promise((resolve) => setTimeout(resolve, time));
@@ -152,24 +139,20 @@ function SignUp(props) {
         .then((response) => response.json())
         .then(function (response) {
           if (response.status === "success") {
-            console.log("Success:", email);
             const loginSuccess = value.handleLogin(email, password);
             if (loginSuccess) props.history.push("/dashboard");
           } else {
             handleSnack(response.message);
-            console.log(response.message);
           }
         })
-        .catch((error) => {
-          console.error("Error:", error);
-        });
+        .catch(() => {});
     }
   };
 
   return (
     <section className={classes.signup}>
       <Box className={classes.formContainer}>
-        <form form onSubmit={handleSignup}>
+        <form onSubmit={handleSignup}>
           <h2 className={classes.h2}>Sign up</h2>
           <label>Your Name</label>
           <TextField
@@ -190,8 +173,6 @@ function SignUp(props) {
             fullWidth
             required
             type="email"
-            // error={!!errors.email}
-            // helperText={errors.email}
             onChange={(e) => setEmail(e.target.value)}
           />
           <label>Password:</label>
@@ -202,8 +183,6 @@ function SignUp(props) {
             fullWidth
             required
             type="password"
-            // error={!!errors.password}
-            // helperText={errors.password}
             inputProps={{ minLength: 6 }}
             onChange={(e) => setPassword(e.target.value)}
           />
@@ -224,13 +203,11 @@ function SignUp(props) {
               required
               type="password"
               error={!!errors.confirm}
-              // helperText={errors.confirm}
               onChange={(e) => setConfirm(e.target.value)}
             />
           </ErrorTooltip>
           <Button
             className={classes.button}
-            // onClick={handleClick}
             type="submit"
             variant="contained"
             color="secondary"
@@ -244,16 +221,11 @@ function SignUp(props) {
             Login
           </Link>
         </Box>
-        <Snackbar
-          open={openSnack}
-          autoHideDuration={6000}
-          onClose={handleCloseSnack}
-          anchorOrigin={{ vertical, horizontal }}
-        >
-          <Alert onClose={handleCloseSnack} severity="error">
-            {snackText}
-          </Alert>
-        </Snackbar>
+        <WarningSnackbar
+          openSnack={openSnack}
+          handleCloseSnack={handleCloseSnack}
+          snackText={snackText}
+        />
       </Box>
     </section>
   );

--- a/client/src/components/SignUp.js
+++ b/client/src/components/SignUp.js
@@ -113,7 +113,6 @@ function SignUp(props) {
     if (reason === "clickaway") {
       return;
     }
-
     setOpenSnack(false);
   };
 

--- a/client/src/components/SignUp.js
+++ b/client/src/components/SignUp.js
@@ -1,19 +1,18 @@
 import React, { useState, useContext } from "react";
 import { Link } from "react-router-dom";
 import { makeStyles } from "@material-ui/core/styles";
-import { Button, TextField, Box, Snackbar, Tooltip } from "@material-ui/core";
+import { Button, TextField, Box, Snackbar, Tooltip} from "@material-ui/core";
 import MuiAlert from "@material-ui/lab/alert";
 import UserContext from "../contexts/UserContext";
 
-function Alert(props) {
-  return <MuiAlert elevation={6} variant="filled" {...props} />;
-}
+// function Alert(props) {
+//   return <MuiAlert elevation={6} variant="filled" {...props} />;
+// }
 
 const useStyles = makeStyles((theme) => ({
-  login: {
+  signup: {
     maxWidth: "1200px",
     margin: "0 auto",
-    height: "123vh",
     padding: "50px",
     backgroundColor: "#44475ab9",
   },
@@ -42,7 +41,7 @@ const useStyles = makeStyles((theme) => ({
     marginTop: "25px",
     backgroundColor: "#DF1B1B",
   },
-  signup: {
+  login: {
     display: "flex",
     padding: "20px",
     borderTop: "1px solid rgba(128, 128, 128, 0.274)",
@@ -65,100 +64,105 @@ function SignUp(props) {
   const [password, setPassword] = useState("");
   const [confirm, setConfirm] = useState("");
   const [errors, setErrors] = useState({});
-  const [openNameTooltip, setOpenNameTooltip] = useState(false);
-  const [openSnack, setOpenSnack] = useState(false);
-  const [snackText, setSnackText] = useState("");
+  // const [openNameTooltip, setOpenNameTooltip] = useState(false);
+  // const [openSnack, setOpenSnack] = useState(false);
+  // const [snackText, setSnackText] = useState("");
   const value = useContext(UserContext);
 
-  const handleNameTooltip = () => {
-    setOpenNameTooltip(true);
-  };
+  // const handleNameTooltip = () => {
+  //   setOpenNameTooltip(true);
+  // };
 
-  const handleSnack = (props) => {
-    setSnackText(props);
-    setOpenSnack(true);
-  };
+  // const handleSnack = (props) => {
+  //   setSnackText(props);
+  //   setOpenSnack(true);
+  // };
 
-  const handleCloseSnack = (event, reason) => {
-    if (reason === "clickaway") {
-      return;
-    }
+  // const handleCloseSnack = (event, reason) => {
+  //   if (reason === "clickaway") {
+  //     return;
+  //   }
 
-    setOpenSnack(false);
-  };
+  //   setOpenSnack(false);
+  // };
 
-  const validations = () => {
-    const errorsCopy = { ...errors };
-    errorsCopy.name = name ? "" : "This field is required.";
-    if (errorsCopy.name) {
-      setOpenNameTooltip(true);
-    }
-    errorsCopy.email = /.+@.+\..+/.test(email) ? "" : "Email is not valid.";
-    errorsCopy.password =
-      password.length > 5 ? "" : "Password must be at least six characters.";
-    errorsCopy.confirm = password === confirm ? "" : "Passwords must match.";
-    setErrors({ ...errorsCopy });
+  // const validations = () => {
+  //   const errorsCopy = { ...errors };
+  //   errorsCopy.name = name ? "" : "This field is required.";
+  //   if (errorsCopy.name) {
+  //     setOpenNameTooltip(true);
+  //   }
+  //   errorsCopy.email = /.+@.+\..+/.test(email) ? "" : "Email is not valid.";
+  //   errorsCopy.password =
+  //     password.length > 5 ? "" : "Password must be at least six characters.";
+  //   errorsCopy.confirm = password === confirm ? "" : "Passwords must match.";
+  //   setErrors({ ...errorsCopy });
 
-    return Object.values(errorsCopy).every((field) => field === "");
-  };
+  //   return Object.values(errorsCopy).every((field) => field === "");
+  // };
 
-  const handleClick = async (e) => {
+  // const handleSignup = async (e) => {
+  //   e.preventDefault();
+  //   if (true) {
+  //     fetch("/auth/register", {
+  //       method: "POST",
+  //       headers: {
+  //         "Content-Type": "application/json",
+  //       },
+  //       body: JSON.stringify({
+  //         name: name,
+  //         email: email,
+  //         password: password,
+  //         confirm: confirm,
+  //       }),
+  //     })
+  //       .then((response) => response.json())
+  //       .then(function (response) {
+  //         if (response.status === "success") {
+  //           console.log("Success:", email);
+  //           const loginSuccess = value.handleLogin(email, password);
+  //           if (loginSuccess) props.history.push("/dashboard");
+  //         } else {
+  //           // handleSnack(response.message);
+  //           console.log(response.message);
+  //         }
+  //       })
+  //       .catch((error) => {
+  //         console.error("Error:", error);
+  //       });
+  //   }
+  // };
+  const handleSubmit = (e) => {
     e.preventDefault();
-    if (validations()) {
-      fetch("/auth/register", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          name: name,
-          email: email,
-          password: password,
-          confirm: confirm,
-        }),
-      })
-        .then((response) => response.json())
-        .then(function (response) {
-          if (response.status === "success") {
-            console.log("Success:", email);
-            const loginSuccess = value.handleLogin(email, password);
-            if (loginSuccess) props.history.push("/dashboard");
-          } else {
-            handleSnack(response.message);
-            console.log(response.message);
-          }
-        })
-        .catch((error) => {
-          console.error("Error:", error);
-        });
-    }
+    const signupSuccess = value.handleSignup(name, email, password, confirm);
+    if (signupSuccess) props.history.push("/dashboard");
   };
 
   return (
-    <section className={classes.login}>
+    <section className={classes.signup}>
       <Box className={classes.formContainer}>
-        <form>
+        <form form onSubmit={handleSubmit}>
           <h2 className={classes.h2}>Sign up</h2>
           <label>Your Name</label>
-          <Tooltip
+          {/* <Tooltip
             open={openNameTooltip}
             title={errors.name}
             arrow
             disableHoverListener
             disableTouchListener
             disableFocusListener
-          >
+          > */}
             <TextField
               className={classes.textField}
               variant="outlined"
               label="name"
               fullWidth
               required
-              type="text"
-              error={!!errors.name}
+              // type="text"
+              // error={!!errors.name}
               onChange={(e) => setName(e.target.value)}
             />
-          </Tooltip>
+          {/* </Tooltip> */}
           <label>Your email address:</label>
           <TextField
             className={classes.textField}
@@ -167,8 +171,8 @@ function SignUp(props) {
             fullWidth
             required
             type="email"
-            error={!!errors.email}
-            helperText={errors.email}
+            // error={!!errors.email}
+            // helperText={errors.email}
             onChange={(e) => setEmail(e.target.value)}
           />
           <label>Password:</label>
@@ -179,8 +183,9 @@ function SignUp(props) {
             fullWidth
             required
             type="password"
-            error={!!errors.password}
-            helperText={errors.password}
+            // error={!!errors.password}
+            // helperText={errors.password}
+            inputProps={{ minLength: 6 }}
             onChange={(e) => setPassword(e.target.value)}
           />
           <label>Confirm Password:</label>
@@ -191,27 +196,27 @@ function SignUp(props) {
             fullWidth
             required
             type="password"
-            error={!!errors.confirm}
-            helperText={errors.confirm}
+            // error={!!errors.confirm}
+            // helperText={errors.confirm}
             onChange={(e) => setConfirm(e.target.value)}
           />
           <Button
             className={classes.button}
-            onClick={handleClick}
-            //type="submit"
+            // onClick={handleClick}
+            type="submit"
             variant="contained"
             color="secondary"
           >
             Sign up
           </Button>
         </form>
-        <Box className={classes.signup}>
+        <Box className={classes.login}>
           <p className={classes.p}>Already have an account?</p>
           <Link className={classes.signupLink} to="/">
             Login
           </Link>
         </Box>
-        <Snackbar
+        {/* <Snackbar
           open={openSnack}
           autoHideDuration={6000}
           onClose={handleCloseSnack}
@@ -219,7 +224,7 @@ function SignUp(props) {
           <Alert onClose={handleCloseSnack} severity="error">
             {snackText}
           </Alert>
-        </Snackbar>
+        </Snackbar> */}
       </Box>
     </section>
   );

--- a/client/src/components/WarningSnackbar.js
+++ b/client/src/components/WarningSnackbar.js
@@ -1,0 +1,27 @@
+import React from "react";
+import { Snackbar } from "@material-ui/core";
+import MuiAlert from "@material-ui/lab/alert";
+
+function WarningSnackbar(props) {
+  const { openSnack, handleCloseSnack, snackText } = props;
+  function Alert(props) {
+    return <MuiAlert elevation={6} variant="filled" {...props} />;
+  }
+  const vertical = "top";
+  const horizontal = "center";
+
+  return (
+    <Snackbar
+      open={openSnack}
+      autoHideDuration={6000}
+      onClose={handleCloseSnack}
+      anchorOrigin={{ vertical, horizontal }}
+    >
+      <Alert onClose={handleCloseSnack} severity="error">
+        {snackText}
+      </Alert>
+    </Snackbar>
+  );
+}
+
+export default WarningSnackbar;

--- a/client/src/contexts/UserContext.js
+++ b/client/src/contexts/UserContext.js
@@ -17,8 +17,10 @@ export function UserStore(props) {
       .catch((error) => {
         setUser(false);
       });
+
   const [user, setUser] = useState(checkCookie());
-  const handleSignup = (name, email, password, confirm) => {
+
+  const handleSignup = (name, email, password, confirm) =>
     fetch("/auth/register", {
       method: "POST",
       headers: {
@@ -35,15 +37,14 @@ export function UserStore(props) {
       .then(function (response) {
         if (response.status === "success") {
           setUser(true);
-          return true;
+          return response;
         } else {
-          return false;
+          return response;
         }
       })
       .catch((error) => {
         return false;
       });
-  };
 
   const handleLogin = (email, password) =>
     fetch("/auth/login", {
@@ -62,6 +63,7 @@ export function UserStore(props) {
           setUser(true);
           return response;
         } else {
+          return response;
         }
       })
       .catch((error) => {

--- a/client/src/contexts/UserContext.js
+++ b/client/src/contexts/UserContext.js
@@ -8,7 +8,7 @@ export function UserStore(props) {
     })
       .then((response) => response.json())
       .then((response) => {
-d        if (response.status === "success") {
+        if (response.status === "success") {
           setUser(true);
         } else {
           setUser(false);

--- a/client/src/contexts/UserContext.js
+++ b/client/src/contexts/UserContext.js
@@ -2,7 +2,26 @@ import React, { useState } from "react";
 const UserContext = React.createContext({});
 
 export function UserStore(props) {
-  const [user, setUser] = useState(false);
+  const checkCookie = () =>
+    fetch("/auth/status", {
+      method: "GET",
+    })
+      .then((response) => response.json())
+      .then((response) => {
+        if (response.status === "success") {
+          console.log("It worked");
+          setUser(true);
+        } else {
+          console.log("It failed");
+          setUser(false);
+        }
+      })
+      .catch((error) => {
+        console.error("Error:", error);
+        setUser(false);
+      });
+
+  const [user, setUser] = useState(checkCookie());
 
   const handleLogin = (email, password) =>
     fetch("/auth/login", {
@@ -43,6 +62,7 @@ export function UserStore(props) {
         user: user,
         handleLogin: handleLogin,
         handleLogout: handleLogout,
+        checkCookie: checkCookie,
       }}
     >
       {props.children}

--- a/client/src/contexts/UserContext.js
+++ b/client/src/contexts/UserContext.js
@@ -15,7 +15,6 @@ export function UserStore(props) {
         }
       })
       .catch((error) => {
-        console.error("Error:", error);
         setUser(false);
       });
   const [user, setUser] = useState(checkCookie());
@@ -35,16 +34,13 @@ export function UserStore(props) {
       .then((response) => response.json())
       .then(function (response) {
         if (response.status === "success") {
-          console.log("Success:", email);
           setUser(true);
           return true;
         } else {
-          console.log(response.message);
           return false;
         }
       })
       .catch((error) => {
-        console.error("Error:", error);
         return false;
       });
   };
@@ -62,17 +58,13 @@ export function UserStore(props) {
     })
       .then((response) => response.json())
       .then((response) => {
-        console.log(response);
         if (response.status === "success") {
-          console.log("Success:", email);
           setUser(true);
-          return true;
+          return response;
         } else {
-          console.log(response.message);
         }
       })
       .catch((error) => {
-        console.error("Error:", error);
         return false;
       });
 
@@ -82,15 +74,9 @@ export function UserStore(props) {
     })
       .then((response) => response.json())
       .then((response) => {
-        if (response.status === "success") {
-          console.log("Logout successful");
-          setUser(false);
-        } else {
-          setUser(false);
-        }
+        setUser(false);
       })
       .catch((error) => {
-        console.error("Error:", error);
         setUser(false);
       });
   };

--- a/client/src/contexts/UserContext.js
+++ b/client/src/contexts/UserContext.js
@@ -8,11 +8,9 @@ export function UserStore(props) {
     })
       .then((response) => response.json())
       .then((response) => {
-        if (response.status === "success") {
-          console.log("It worked");
+d        if (response.status === "success") {
           setUser(true);
         } else {
-          console.log("It failed");
           setUser(false);
         }
       })
@@ -53,7 +51,22 @@ export function UserStore(props) {
       });
 
   const handleLogout = () => {
-    setUser(false);
+    fetch("/auth/logout", {
+      method: "GET",
+    })
+      .then((response) => response.json())
+      .then((response) => {
+        if (response.status === "success") {
+          console.log("Logout successful");
+          setUser(false);
+        } else {
+          setUser(false);
+        }
+      })
+      .catch((error) => {
+        console.error("Error:", error);
+        setUser(false);
+      });
   };
 
   return (

--- a/client/src/contexts/UserContext.js
+++ b/client/src/contexts/UserContext.js
@@ -18,8 +18,39 @@ export function UserStore(props) {
         console.error("Error:", error);
         setUser(false);
       });
-
   const [user, setUser] = useState(checkCookie());
+  const handleSignup =(name, email, password, confirm) => {
+    
+      fetch("/auth/register", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          name: name,
+          email: email,
+          password: password,
+          confirm: confirm,
+        }),
+      })
+        .then((response) => response.json())
+        .then(function (response) {
+          if (response.status === "success") {
+            console.log("Success:", email);
+            setUser(true);
+            return true;
+          } else {
+            // handleSnack(response.message);
+            console.log(response.message);
+            return false;
+          }
+        })
+        .catch((error) => {
+          console.error("Error:", error);
+          return false;
+        });
+    
+  };
 
   const handleLogin = (email, password) =>
     fetch("/auth/login", {
@@ -75,7 +106,7 @@ export function UserStore(props) {
         user: user,
         handleLogin: handleLogin,
         handleLogout: handleLogout,
-        checkCookie: checkCookie,
+        handleSignup: handleSignup,
       }}
     >
       {props.children}

--- a/client/src/contexts/UserContext.js
+++ b/client/src/contexts/UserContext.js
@@ -19,37 +19,34 @@ export function UserStore(props) {
         setUser(false);
       });
   const [user, setUser] = useState(checkCookie());
-  const handleSignup =(name, email, password, confirm) => {
-    
-      fetch("/auth/register", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          name: name,
-          email: email,
-          password: password,
-          confirm: confirm,
-        }),
-      })
-        .then((response) => response.json())
-        .then(function (response) {
-          if (response.status === "success") {
-            console.log("Success:", email);
-            setUser(true);
-            return true;
-          } else {
-            // handleSnack(response.message);
-            console.log(response.message);
-            return false;
-          }
-        })
-        .catch((error) => {
-          console.error("Error:", error);
+  const handleSignup = (name, email, password, confirm) => {
+    fetch("/auth/register", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        name: name,
+        email: email,
+        password: password,
+        confirm: confirm,
+      }),
+    })
+      .then((response) => response.json())
+      .then(function (response) {
+        if (response.status === "success") {
+          console.log("Success:", email);
+          setUser(true);
+          return true;
+        } else {
+          console.log(response.message);
           return false;
-        });
-    
+        }
+      })
+      .catch((error) => {
+        console.error("Error:", error);
+        return false;
+      });
   };
 
   const handleLogin = (email, password) =>
@@ -71,9 +68,7 @@ export function UserStore(props) {
           setUser(true);
           return true;
         } else {
-          window.alert(response.message);
           console.log(response.message);
-          return false;
         }
       })
       .catch((error) => {

--- a/client/src/pages/LandingPage.js
+++ b/client/src/pages/LandingPage.js
@@ -1,0 +1,36 @@
+import React, { useState } from "react";
+import { Box, Dialog, Button } from "@material-ui/core";
+import SignUp from "components/SignUp";
+import Login from "components/Login";
+
+const LandingPage = () => {
+  const [openSignup, setOpenSignup] = useState(false);
+  const [openLogin, setOpenLogin] = useState(false);
+
+  const handleOpenSignup = () => {
+    setOpenSignup(true);
+  };
+
+  const handleOpenLogin = () => {
+    setOpenLogin(true);
+  };
+
+  return (
+    <Box>
+      <Button onClick={handleOpenSignup} variant="contained" color="secondary">
+        Sign Up
+      </Button>
+      <Button onClick={handleOpenLogin} variant="contained" color="secondary">
+        Login
+      </Button>
+      <Dialog open={openSignup}>
+        <SignUp />
+      </Dialog>
+      <Dialog open={openLogin}>
+        <Login />
+      </Dialog>
+    </Box>
+  );
+};
+
+export default LandingPage;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,3 @@
+{
+  "lockfileVersion": 1
+}

--- a/server/api/auth_handler.py
+++ b/server/api/auth_handler.py
@@ -1,4 +1,5 @@
 from models.user import User
+from models.blacklist_token import BlacklistToken
 from flask import Blueprint, request, make_response, jsonify, g, redirect, url_for
 from flask.views import MethodView
 from database import db
@@ -16,6 +17,16 @@ def login_cookie_getter(f):
             auth_header = request.cookies.get("Authentication token")
             if auth_header:
                 auth_token = auth_header
+                blacklist_check = BlacklistToken.query.filter_by(
+                    token=auth_token
+                ).first()
+                if blacklist_check:
+                    responseObject = {
+                        "status": "failure",
+                        "message": "Invalid authentication token, please logout."
+                    }
+                    resp = make_response(jsonify(responseObject))
+                    return resp, 401
                 auth_token = User.decode_auth_token(auth_token)
                 if not isinstance(auth_token, str):
                     g.user = User.query.filter_by(id=auth_token).first()
@@ -61,15 +72,26 @@ class RegisterAPI(MethodView):
                 db.session.add(user)
                 db.session.commit()
                 auth_token = user.encode_auth_token(user.id)
-                g.user = user
-                responseObject = {
-                    "status": "success",
-                    "message": "Successfully registered."
-                }
-                resp = make_response(jsonify(responseObject))
-                resp.set_cookie("Authentication token",
-                                auth_token, httponly=True)
-                return resp, 201
+                blacklist_check = BlacklistToken.query.filter_by(
+                    token=str(auth_token)
+                ).first()
+                if blacklist_check:
+                    responseObject = {
+                        "status": "failure",
+                        "message": "Some error occurred. Please try again."
+                    }
+                    resp = make_response(jsonify(responseObject))
+                    return resp, 401
+                else:
+                    g.user = user
+                    responseObject = {
+                        "status": "success",
+                        "message": "Successfully registered."
+                    }
+                    resp = make_response(jsonify(responseObject))
+                    resp.set_cookie("Authentication token",
+                                    auth_token, httponly=True)
+                    return resp, 201
             except Exception as e:
                 responseObject = {
                     "status": "fail",
@@ -96,6 +118,22 @@ class LoginAPI(MethodView):
             ):
                 auth_token = user.encode_auth_token(user.id)
                 if auth_token:
+                    print("hello")
+                    try:
+                        blacklist_check = BlacklistToken.query.filter_by(
+                            token=str(auth_token)
+                        ).first()
+                    except Exception as e:
+                        print(e)
+                        return "Error"
+                    print("hello")
+                    if blacklist_check:
+                        responseObject = {
+                            "status": "failure",
+                            "message": "Some error occurred. Please try again."
+                        }
+                        resp = make_response(jsonify(responseObject))
+                        return resp, 401
                     responseObject = {
                         "status": "success",
                         "message": "Successfully logged in"
@@ -147,18 +185,28 @@ class UserAPI(MethodView):
 
 class LogoutAPI(MethodView):
     def get(self):
-        responseObject = {
-            "status": "success",
-            "message": "Logout successful"
-        }
         try:
             auth_token = request.cookies.get("Authentication token")
+            responseObject = {
+                "status": "success",
+                "message": "Logout successful"
+            }
+            resp = make_response(jsonify(responseObject))
+            resp.delete_cookie("Authentication token")
+            token = BlacklistToken(
+                    token=auth_token
+                )
+            db.session.add(token)
+            db.session.commit()
+            return resp, 200
         except:
-            return "Already logged out!", 401
-        
-        resp = make_response(jsonify(responseObject))
-        resp.delete_cookie("Authentication token")
-        return resp, 200
+            responseObject = {
+                "status": "failure",
+                "message": "Already logged out!"
+            }
+            resp = make_response(jsonify(responseObject))
+            resp.delete_cookie("Authentication token")
+            return resp, 401
 
 
 # Basic middleware for protected routes pulled from Flask's documentation.

--- a/server/api/auth_handler.py
+++ b/server/api/auth_handler.py
@@ -151,6 +151,11 @@ class LogoutAPI(MethodView):
             "status": "success",
             "message": "Logout successful"
         }
+        try:
+            auth_token = request.cookies.get("Authentication token")
+        except:
+            return "Already logged out!", 401
+        
         resp = make_response(jsonify(responseObject))
         resp.delete_cookie("Authentication token")
         return resp, 200

--- a/server/api/auth_handler.py
+++ b/server/api/auth_handler.py
@@ -92,7 +92,7 @@ class RegisterAPI(MethodView):
                     resp.set_cookie("Authentication token",
                                     auth_token, httponly=True)
                     return resp, 201
-            except Exception as e:
+            except Exception:
                 responseObject = {
                     "status": "fail",
                     "message": "Some error occurred. Please try again."
@@ -118,15 +118,12 @@ class LoginAPI(MethodView):
             ):
                 auth_token = user.encode_auth_token(user.id)
                 if auth_token:
-                    print("hello")
                     try:
                         blacklist_check = BlacklistToken.query.filter_by(
                             token=str(auth_token)
                         ).first()
-                    except Exception as e:
-                        print(e)
+                    except Exception:
                         return "Error"
-                    print("hello")
                     if blacklist_check:
                         responseObject = {
                             "status": "failure",
@@ -160,7 +157,7 @@ class LoginAPI(MethodView):
                     "message": "User does not exist."
                 }
                 return make_response(jsonify(responseObject)), 404
-        except Exception as e:
+        except Exception:
             responseObject = {
                 "status": "fail",
                 "message": "Try again"

--- a/server/api/auth_handler.py
+++ b/server/api/auth_handler.py
@@ -145,6 +145,17 @@ class UserAPI(MethodView):
         return make_response(jsonify(responseObject)), 200
 
 
+class LogoutAPI(MethodView):
+    def get(self):
+        responseObject = {
+            "status": "success",
+            "message": "Logout successful"
+        }
+        resp = make_response(jsonify(responseObject))
+        resp.delete_cookie("Authentication token")
+        return resp, 200
+
+
 # Basic middleware for protected routes pulled from Flask's documentation.
 def login_required(f):
     @wraps(f)
@@ -159,6 +170,7 @@ def login_required(f):
 registration_view = RegisterAPI.as_view("register_api")
 login_view = LoginAPI.as_view("login_api")
 user_view = UserAPI.as_view("user_api")
+logout_view = LogoutAPI.as_view("logout_api")
 
 auth_handler.add_url_rule(
     "/auth/register",
@@ -173,5 +185,10 @@ auth_handler.add_url_rule(
 auth_handler.add_url_rule(
     "/auth/status",
     view_func=user_view,
+    methods=["GET"]
+)
+auth_handler.add_url_rule(
+    "/auth/logout",
+    view_func=logout_view,
     methods=["GET"]
 )

--- a/server/models/blacklist_token.py
+++ b/server/models/blacklist_token.py
@@ -16,5 +16,3 @@ class BlacklistToken(db.Model):
 
     def __repr__(self):
         return f"<id: token: {self.token}"
-
-    

--- a/server/models/blacklist_token.py
+++ b/server/models/blacklist_token.py
@@ -1,0 +1,20 @@
+from database import db
+from config import DevelopmentConfig
+import datetime
+
+class BlacklistToken(db.Model):
+
+    __tablename__ = "blacklist_tokens"
+
+    id = db.Column(db.Integer, primary_key=True, autoincrement=True)
+    token = db.Column(db.String(500), unique=True, nullable=False)
+    blacklist_time = db.Column(db.DateTime, nullable=False)
+
+    def __init__(self, token):
+        self.token = token
+        self.blacklist_time = datetime.datetime.now(tz=datetime.timezone.utc)
+
+    def __repr__(self):
+        return f"<id: token: {self.token}"
+
+    


### PR DESCRIPTION
--What it does--
Fixes bug where refreshing dashboard logs user out.
Causes logout button to delete cookie, using a backend logout API.
Adjusts styling on signup page to accommodate tooltip messages.
Adds a tooltip message to warn a user that their input is invalid on confirm password.
Uses HTML alerts on other front-end based invalid inputs
Adds snackbars on signup page when the back-end throws an error.
Adds snackbars on the login page.
Introduces minor bug where a logged out user can briefly see the dashboard when "/dashboard" is the route.
Introduces minor bug where a user may be redirected to the login page briefly before going to the dashboard when signing up.
Implements the framework for a landing page and associated dialogs.
Blacklists authentication tokens when a user logs out and adds the associated database model.
Checks if an authentication token is blacklisted when a user logs out.

--What it avoids--
It doesn't style the landing page much at all. I was going to add a close button to the dialogs opened by the sign up and login buttons, but I will be busy the rest of today and I felt like that would be a very minor thing to hold up this pull request for, especially since this pull request already covers a fair bit of ground, and the goal was more to provide a skeleton for the landing page rather than a full-fledged landing page.

--What to look for--
If the styling works, especially on the warnings now given when users input info that is wrong or invalid.
If there are any bugs not already noted.
If there is a way to fix the minor bugs noted above.