### PR TITLE
Bugfix: Scraper High Prices

### DIFF
--- a/client/src/components/ItemDisplay.js
+++ b/client/src/components/ItemDisplay.js
@@ -56,10 +56,24 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
+const reverseString = (string) => string.split("").reverse().join("");
+
+const addCommasToDollars = (dollars) => {
+  let dollarsString = String(dollars);
+  dollarsString = reverseString(dollarsString);
+  dollarsString = dollarsString.replace(/(.{3})/g, "$1,");
+  dollarsString = reverseString(dollarsString);
+  return dollarsString.startsWith(",")
+    ? dollarsString.substring(1)
+    : dollarsString;
+};
+
 const centsToDollarsDisplay = (inputCents) => {
   const dollars = String(Math.floor(inputCents / 100));
   const cents = String(inputCents % 100);
-  return `${dollars}.${cents.length > 1 ? cents : "0" + cents}`;
+  const dollarsString = addCommasToDollars(dollars);
+  const centsString = cents.length > 1 ? cents : "0" + cents;
+  return `${dollarsString}.${centsString}`;
 };
 
 const ItemDisplay = (props) => {

--- a/client/src/components/ItemDisplay.js
+++ b/client/src/components/ItemDisplay.js
@@ -42,7 +42,8 @@ const useStyles = makeStyles((theme) => ({
     noWrap: "true",
   },
   priceTextContainer: {
-    display: "inlineflex",
+    display: "inline-flex",
+    whiteSpace: "pre-wrap",
     padding: theme.spacing(0.25),
   },
   itemOldPrice: {
@@ -100,9 +101,10 @@ const ItemDisplay = (props) => {
         <Box className={classes.priceTextContainer}>
           {old_price && (
             <Typography className={classes.itemOldPrice}>
-              {currency + centsToDollarsDisplay(old_price)}{" "}
+              {currency + centsToDollarsDisplay(old_price)}
             </Typography>
-          )}{" "}
+          )}
+          <Typography> </Typography>
           <Typography className={classes.itemPrice}>
             {currency + centsToDollarsDisplay(price)}
           </Typography>

--- a/client/src/components/ItemDisplay.js
+++ b/client/src/components/ItemDisplay.js
@@ -59,7 +59,7 @@ const useStyles = makeStyles((theme) => ({
 
 // Adds a comma once every 3 digits right to left
 const addCommasToDollars = (dollars) => {
-  let dollarsArray = String(dollars).split("");
+  let dollarsArray = dollars.split("");
   for (let i = dollarsArray.length - 3; i > 0; i = i - 3)
     dollarsArray.splice(i, 0, ",");
   return dollarsArray.join("");

--- a/client/src/components/ItemDisplay.js
+++ b/client/src/components/ItemDisplay.js
@@ -57,6 +57,7 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
+// Adds a comma once every 3 digits right to left
 const addCommasToDollars = (dollars) => {
   let dollarsArray = String(dollars).split("");
   for (let i = dollarsArray.length - 3; i > 0; i = i - 3)

--- a/client/src/components/ItemDisplay.js
+++ b/client/src/components/ItemDisplay.js
@@ -57,16 +57,11 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-const reverseString = (string) => string.split("").reverse().join("");
-
 const addCommasToDollars = (dollars) => {
-  let dollarsString = String(dollars);
-  dollarsString = reverseString(dollarsString);
-  dollarsString = dollarsString.replace(/(.{3})/g, "$1,");
-  dollarsString = reverseString(dollarsString);
-  return dollarsString.startsWith(",")
-    ? dollarsString.substring(1)
-    : dollarsString;
+  let dollarsArray = String(dollars).split("");
+  for (let i = dollarsArray.length - 3; i > 0; i = i - 3)
+    dollarsArray.splice(i, 0, ",");
+  return dollarsArray.join("");
 };
 
 const centsToDollarsDisplay = (inputCents) => {

--- a/server/api/scraper.py
+++ b/server/api/scraper.py
@@ -17,8 +17,8 @@ def loadChromeDriver():
 
 def string_to_int_price(price_string):
     if price_string == None: return None
-    price_match = re.search(r"([0-9]+)[\,|\.]([0-9]+)", price_string) 
-    return int(price_match.group(1)) * 100 + int(price_match.group(2))
+    price_match = re.sub(r"[^0-9]", "", price_string)
+    return int(price_match)
 
 def string_availability_to_boolean(string_availability):
     if string_availability == None: return None


### PR DESCRIPTION
**What it does**
- Fixes bug where items prices with more than 3 digits would scrape in correctly
    - Scraper now removes all non numeric units and returns the parsed int as the number of cents, instead of splitting the string based on commas/dots
    - Note: currently (& previously) only works with currencies that have a fractional unit of 1/100 (i.e. [Japan](https://www.amazon.co.jp) or [India](https://www.amazon.in/) Amazon stores will both display incorrectly)
- Also re-fixes incorrect white-space in currency display