### PR TITLE
Hotfix auth handler again

### DIFF
--- a/server/api/auth_handler.py
+++ b/server/api/auth_handler.py
@@ -15,7 +15,7 @@ def token_getter():
         if auth_header:
             auth_token = auth_header
             blacklist_check = BlacklistToken.query.filter_by(
-                token=int(auth_token)
+                token=str(auth_token)
                 ).first()
             if blacklist_check:
                 responseObject = {


### PR DESCRIPTION
I had an error in the original hotfix that converted the auth token to an int instead of a string, causing the blacklist checker to cause the authentication to break. This should fix it.